### PR TITLE
FEAT/ 영상 가져오기 버튼, 플레이 버튼 구현

### DIFF
--- a/src/app/(youtube)/youtube/page.tsx
+++ b/src/app/(youtube)/youtube/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/input';
+
+import { Heading1 } from '@/components/ui/Heading';
+import { useRef, useState } from 'react';
+
+export default function Page() {
+  const [isPlay, setIsplay] = useState(false);
+  const inputRef = useRef<HTMLInputElement>();
+  const iframeRef = useRef<HTMLIFrameElement>();
+  const playBtnRef = useRef<HTMLButtonElement>();
+
+  const onClickTake = () => {
+    const videoId = inputRef.current.value.split('v=')[1].split('&')[0];
+    iframeRef.current.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&loop=1&playlist=${videoId}&enablejsapi=1&autohide=0`;
+    setIsplay(true);
+    playBtnRef.current.innerHTML = '일시정지';
+  };
+
+  const onClickPlay = () => {
+    const postMessage = isPlay ? 'pauseVideo' : 'playVideo';
+    playBtnRef.current.innerHTML = isPlay ? '재생' : '일시정지';
+    iframeRef.current.contentWindow.postMessage(
+      `{"event":"command","func":"${postMessage}"}`,
+      '*',
+    );
+    setIsplay(!isPlay);
+  };
+
+  return (
+    <div className="inline-flex flex-col gap-y-10 p-8">
+      <Heading1 className="text-primary">유투브 음원 재생하기!</Heading1>
+      <div className="inline-grid grid-cols-3 gap-2">
+        <Input
+          ref={inputRef}
+          type="text"
+          defaultValue="https://www.youtube.com/watch?v=3AoruwUKQ3I"
+        />
+        <Button type="submit" onClick={onClickTake}>
+          가져오기
+        </Button>
+        <Button ref={playBtnRef} onClick={onClickPlay} variant="secondary">
+          재생
+        </Button>
+      </div>
+      <iframe
+        className="hidden"
+        title="youtube"
+        ref={iframeRef}
+        width="500"
+        height="50"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      />
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+import { cn } from '@/style/utils';
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input };


### PR DESCRIPTION
## 작업내용

<!---
어떤 작업을 했는지 설명을 작성해 주세요.
리뷰어가 PR 내용만으로 어떤 변경이 있는지 모두 알 수 있도록 작성해 주세요.
-->
- /youtube 페이지 추가
- 영상 가져오기 / 재생, 일시정지 버튼 구현
- shadcn에서 ui/input.tsx 복붙

## 리뷰노트
<!---
리뷰어가 PR를 리뷰하기 앞서 미리 알려드리고 싶은 내용을 작성해주세요.
-->
추가로 시도할것들
- 영상제목 표시하기
- 쇼츠도 재생하기
- 잘못된 주소 일경우 흔들리게 만들기
- 재생바 만들어보기
- 유투브 api 사용해서 영상 검색기능 간단하게 만들어보기

## 스크린샷
<!---
코드 이외에 화면의 UI/UX를 스크린샷으로 남겨주세요.
-->
![image](https://github.com/user-attachments/assets/7cdc75d1-51ab-4c65-81db-ff3b24704412)

### 개발 체크리스트

<!--- 아래 목록을 확인하시고 `x` 표시를 해주세요. -->

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
