### PR TITLE
feat: 모바일 랜딩 페이지 메뉴를 세로 정렬로 수정합니다.

### DIFF
--- a/src/containers/landing/menu-list/menu-list.tsx
+++ b/src/containers/landing/menu-list/menu-list.tsx
@@ -8,7 +8,7 @@ function MenuList() {
   const domainURL = getDomainURL();
 
   return (
-    <div className="flex gap-x-6">
+    <div className="flex gap-6 flex-col md:flex-row">
       <Button size="lg" variant="primary" asChild>
         <PopupLink size={7 / 8} url={`${domainURL}${ROUTE.TIMER}`}>
           타이머


### PR DESCRIPTION
## 작업내용

<!---
어떤 작업을 했는지 설명을 작성해 주세요.
리뷰어가 PR 내용만으로 어떤 변경이 있는지 모두 알 수 있도록 작성해 주세요.
-->

- flex의 정렬을 column을 기본으로하고 md 사이즈 이상일 경우 row로 수정하여 모바일 화면에서 레아이웃이 깨지지 않도록 합니다.

## 리뷰노트

<!---
리뷰어가 PR를 리뷰하기 앞서 미리 알려드리고 싶은 내용을 작성해주세요.
-->

## 스크린샷

### As-is
![스크린샷 2024-11-24 오후 5 53 30](https://github.com/user-attachments/assets/cbb71f95-2c5e-4532-9d1c-371b3bab9fe1)

### To-be-
![스크린샷 2024-11-24 오후 5 53 24](https://github.com/user-attachments/assets/7382bd07-4997-4524-8278-e49aba0df264)

<!---
코드 이외에 화면의 UI/UX를 스크린샷으로 남겨주세요.
-->

### 개발 체크리스트

<!--- 아래 목록을 확인하시고 `x` 표시를 해주세요. -->

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
