### PR TITLE
fix: SSE 오류시 자동으로 재접속을 시도하도록 코드를 변경합니다

### DIFF
--- a/src/hooks/apis/music-request/use-music-sse.ts
+++ b/src/hooks/apis/music-request/use-music-sse.ts
@@ -27,7 +27,6 @@ export function useMusicSSE(
     };
 
     eventSource.onerror = () => {
-      eventSource.close();
       throw new Error('music-sse 연결 오류');
     };
 


### PR DESCRIPTION
## 작업내용

<!---
SSE 오류시 자동으로 재접속을 하도록 오류 발생시 SSE 연결을 자동으로 닫는 코드를 삭제하였습니다
-->

## 리뷰노트

<!---
SSE 연결을 강제로 닫지 않으면 SSE가 끊기더라도 자동으로 브라우저에서 SSE 연결을 다시 자동으로 시도합니다
-->

## 스크린샷

<!---
코드 이외에 화면의 UI/UX를 스크린샷으로 남겨주세요.
-->

### 개발 체크리스트

<!--- 아래 목록을 확인하시고 `x` 표시를 해주세요. -->

- [ ] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [ ] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
