### PR TITLE
feat: 랜덤 모둠 고정 학생 표시 옵션 및 위치 랜덤화 추가

### DIFF
--- a/src/containers/random-team/hooks/useRandomTeamStorage.ts
+++ b/src/containers/random-team/hooks/useRandomTeamStorage.ts
@@ -9,17 +9,14 @@ export type RandomTeamSettings = {
   students: string[];
   teamCount: number;
   preAssignments: PreAssignment[];
+  showFixedMark: boolean; // 추가
 };
 
 const RANDOM_TEAM_SETTINGS_KEY = 'random-team-settings';
 const RANDOM_TEAM_AUTO_RUN_KEY = 'random-team-auto-run';
 
-/**
- * localStorage 안전 읽기
- */
 function readLocalStorage<T>(key: string, fallback: T): T {
   if (typeof window === 'undefined') return fallback;
-
   try {
     const stored = localStorage.getItem(key);
     if (!stored) return fallback;
@@ -29,21 +26,18 @@ function readLocalStorage<T>(key: string, fallback: T): T {
   }
 }
 
-/**
- * 랜덤 모둠 설정 저장 훅
- */
 export function useRandomTeamSettings() {
   const [settings, setSettings] = useState<RandomTeamSettings>(() =>
     readLocalStorage<RandomTeamSettings>(RANDOM_TEAM_SETTINGS_KEY, {
       students: [],
       teamCount: 4,
       preAssignments: [],
+      showFixedMark: true, // 기본값: 표시
     }),
   );
 
   const setRandomTeamSettings = (value: RandomTeamSettings) => {
     setSettings(value);
-
     if (typeof window !== 'undefined') {
       localStorage.setItem(RANDOM_TEAM_SETTINGS_KEY, JSON.stringify(value));
     }
@@ -59,7 +53,6 @@ export function useRandomTeamAutoRun() {
 
   const setRandomTeamAutoRun = (value: boolean) => {
     setAutoRun(value);
-
     if (typeof window !== 'undefined') {
       localStorage.setItem(RANDOM_TEAM_AUTO_RUN_KEY, JSON.stringify(value));
     }

--- a/src/containers/random-team/random-team-container.tsx
+++ b/src/containers/random-team/random-team-container.tsx
@@ -85,6 +85,7 @@ export default function RandomTeamContainer() {
             teamCount={settings.teamCount}
             preAssignments={settings.preAssignments}
             assignRef={assignRef}
+            showFixedMark={settings.showFixedMark}
           />
         </div>
       )}

--- a/src/containers/random-team/settings/funnel/funnel-container.tsx
+++ b/src/containers/random-team/settings/funnel/funnel-container.tsx
@@ -21,6 +21,7 @@ export default function FunnelContainer() {
   const [students, setStudents] = useState<string[]>([]);
   const [teamCount, setTeamCount] = useState<number>(4);
   const [preAssignments, setPreAssignments] = useState<PreAssignment[]>([]);
+  const [showFixedMark, setShowFixedMark] = useState<boolean>(true); // 추가
 
   const [initialized, setInitialized] = useState(false);
 
@@ -31,13 +32,13 @@ export default function FunnelContainer() {
     setStudents(savedSettings.students ?? []);
     setTeamCount(savedSettings.teamCount ?? 4);
     setPreAssignments(savedSettings.preAssignments ?? []);
+    setShowFixedMark(savedSettings.showFixedMark ?? true); // 추가
 
     setInitialized(true);
   }, [savedSettings, initialized]);
 
   useEffect(() => {
     if (!initialized) return;
-
     setPreAssignments((prev) =>
       prev.filter((p) => students.includes(p.student)),
     );
@@ -45,7 +46,6 @@ export default function FunnelContainer() {
 
   useEffect(() => {
     if (!initialized) return;
-
     setPreAssignments((prev) => prev.filter((p) => p.groupIndex < teamCount));
   }, [teamCount, initialized]);
 
@@ -54,6 +54,7 @@ export default function FunnelContainer() {
       students,
       teamCount,
       preAssignments,
+      showFixedMark, // 추가
     });
 
     router.push('/random-team');
@@ -85,7 +86,9 @@ export default function FunnelContainer() {
           students={students}
           teamCount={teamCount}
           preAssignments={preAssignments}
+          showFixedMark={showFixedMark}
           onChangePreAssignments={setPreAssignments}
+          onChangeShowFixedMark={setShowFixedMark}
           onPrev={() => setStep(2)}
           onNext={() => setStep(4)}
         />

--- a/src/containers/random-team/settings/funnel/step-fixed.tsx
+++ b/src/containers/random-team/settings/funnel/step-fixed.tsx
@@ -107,7 +107,7 @@ export default function StepFixed({
         <div>
           <Label className="font-semibold text-sm">고정 학생 표시 🔒</Label>
           <p className="text-xs text-gray-500 mt-0.5">
-            결과 화면에서 고정된 학생에게 자물쇠를 표시합니다.
+            결과 화면에서 고정된 학생을 표시합니다.
           </p>
         </div>
         <button

--- a/src/containers/random-team/settings/funnel/step-fixed.tsx
+++ b/src/containers/random-team/settings/funnel/step-fixed.tsx
@@ -17,7 +17,9 @@ type Props = {
   students: string[];
   teamCount: number;
   preAssignments: PreAssignment[];
+  showFixedMark: boolean; // 추가
   onChangePreAssignments: (list: PreAssignment[]) => void;
+  onChangeShowFixedMark: (value: boolean) => void; // 추가
   onPrev: () => void;
   onNext: () => void;
 };
@@ -26,7 +28,9 @@ export default function StepFixed({
   students,
   teamCount,
   preAssignments,
+  showFixedMark,
   onChangePreAssignments,
+  onChangeShowFixedMark,
   onPrev,
   onNext,
 }: Props) {
@@ -72,10 +76,8 @@ export default function StepFixed({
     e.preventDefault();
     const student = e.dataTransfer.getData('text/plain');
     if (!student) return;
-
     if (assignedStudents.has(student)) return;
     if (getTeamAssignments(groupIndex).length >= maxSize) return;
-
     setLocalAssignments([...localAssignments, { student, groupIndex }]);
   };
 
@@ -85,7 +87,6 @@ export default function StepFixed({
 
   const handleSave = () => {
     onChangePreAssignments(localAssignments);
-
     toast({
       title: '고정 배정이 저장되었습니다.',
       description: `총 ${localAssignments.length}명의 학생이 고정되었습니다.`,
@@ -101,6 +102,30 @@ export default function StepFixed({
         특정 학생을 미리 같은 모둠으로 지정할 수 있습니다.
       </p>
 
+      {/* 🔒 표시 여부 토글 */}
+      <Card className="p-4 w-full flex items-center justify-between">
+        <div>
+          <Label className="font-semibold text-sm">고정 학생 표시 🔒</Label>
+          <p className="text-xs text-gray-500 mt-0.5">
+            결과 화면에서 고정된 학생에게 자물쇠를 표시합니다.
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="고정 학생 표시 여부 토글"
+          onClick={() => onChangeShowFixedMark(!showFixedMark)}
+          className={`relative w-11 h-6 rounded-full transition-colors duration-200 focus:outline-none ${
+            showFixedMark ? 'bg-primary' : 'bg-gray-300'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform duration-200 ${
+              showFixedMark ? 'translate-x-5' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </Card>
+
       <Card className="p-4 w-full">
         <Label className="mb-2 font-semibold text-sm">고정되지 않은 학생</Label>
 
@@ -115,7 +140,6 @@ export default function StepFixed({
               {student}
             </div>
           ))}
-
           {unassignedStudents.length === 0 && (
             <p className="text-xs text-gray-500">남은 학생 없음</p>
           )}
@@ -129,9 +153,7 @@ export default function StepFixed({
             return (
               <Card
                 key={idx}
-                className={`p-1 border-dashed border-2 min-h-[100px] ${
-                  isFull ? 'opacity-50' : ''
-                }`}
+                className={`p-1 border-dashed border-2 min-h-[100px] ${isFull ? 'opacity-50' : ''}`}
                 onDragOver={handleDragOver}
                 onDrop={(e) => handleDrop(e, idx)}
               >
@@ -148,7 +170,6 @@ export default function StepFixed({
                       <span className="truncate max-w-[70px]">
                         {assignment.student}
                       </span>
-
                       <Button
                         variant="gray-ghost"
                         size="sm"
@@ -159,7 +180,6 @@ export default function StepFixed({
                       </Button>
                     </div>
                   ))}
-
                   {teamAssignments.length === 0 && (
                     <p className="text-xs text-gray-500 w-full text-center mt-1">
                       학생 없음

--- a/src/containers/random-team/team-result/team-result.tsx
+++ b/src/containers/random-team/team-result/team-result.tsx
@@ -28,7 +28,7 @@ type Props = {
   teamCount: number;
   preAssignments?: PreAssignment[];
   assignRef?: MutableRefObject<(() => void) | undefined>;
-  showFixedMark?: boolean; // 추가
+  showFixedMark?: boolean;
 };
 
 function makeId(): string {
@@ -47,7 +47,7 @@ export default function TeamResult({
   teamCount,
   preAssignments = [],
   assignRef,
-  showFixedMark = true, // 추가
+  showFixedMark = true,
 }: Props) {
   const [groups, setGroups] = useState<Group[]>([]);
 
@@ -98,7 +98,12 @@ export default function TeamResult({
       capacities[cursor] -= 1;
     });
 
-    setGroups(groupsBase);
+    const shuffledGroups = groupsBase.map((group) => ({
+      ...group,
+      members: shuffle(group.members),
+    }));
+
+    setGroups(shuffledGroups);
   }, [students, teamCount, preAssignments]);
 
   useEffect(() => {
@@ -134,7 +139,7 @@ export default function TeamResult({
                       className={isFixed && showFixedMark ? 'font-bold' : ''}
                     >
                       {member.name}
-                      {isFixed && showFixedMark && ' 🔒'} {/* 수정 */}
+                      {isFixed && showFixedMark && ' 🔒'}
                     </li>
                   );
                 })}

--- a/src/containers/random-team/team-result/team-result.tsx
+++ b/src/containers/random-team/team-result/team-result.tsx
@@ -28,6 +28,7 @@ type Props = {
   teamCount: number;
   preAssignments?: PreAssignment[];
   assignRef?: MutableRefObject<(() => void) | undefined>;
+  showFixedMark?: boolean; // 추가
 };
 
 function makeId(): string {
@@ -46,6 +47,7 @@ export default function TeamResult({
   teamCount,
   preAssignments = [],
   assignRef,
+  showFixedMark = true, // 추가
 }: Props) {
   const [groups, setGroups] = useState<Group[]>([]);
 
@@ -127,9 +129,12 @@ export default function TeamResult({
                   );
 
                   return (
-                    <li key={member.id} className={isFixed ? 'font-bold' : ''}>
+                    <li
+                      key={member.id}
+                      className={isFixed && showFixedMark ? 'font-bold' : ''}
+                    >
                       {member.name}
-                      {isFixed && ' 🔒'}
+                      {isFixed && showFixedMark && ' 🔒'} {/* 수정 */}
                     </li>
                   );
                 })}


### PR DESCRIPTION
## 작업내용

<!---
어떤 작업을 했는지 설명을 작성해 주세요.
리뷰어가 PR 내용만으로 어떤 변경이 있는지 모두 알 수 있도록 작성해 주세요.
-->

- [ ] 랜덤 모둠 뽑기에서 팀에 고정된 학생을 뽑기 결과에서 표시하지 않을 수 있는 옵션 추가
- [ ] 고정된 학생의 이름 위치를 뽑기 결과에서 랜덤하게 보여주는 기능 추가

## 리뷰노트

<!---
리뷰어가 PR를 리뷰하기 앞서 미리 알려드리고 싶은 내용을 작성해주세요.
-->

- [ ] 원래 팀에 고정된 학생은 뽑기 결과에서 무조건 눈에 보이도록 표시했으나 표시하지 않을 수 있는 옵션 추가
- [ ] 원래 고정된 학생의 이름은 모둠 뽑기 결과에서 무조건 최상단에 위치했으나 위치를 랜덤하게 보여주는 기능 추가

## 스크린샷

<!---
코드 이외에 화면의 UI/UX를 스크린샷으로 남겨주세요.
-->
<img width="914" height="863" alt="image" src="https://github.com/user-attachments/assets/ae70d6f1-20c5-42ad-bbc9-3a8dca20f725" />
<img width="1334" height="688" alt="image" src="https://github.com/user-attachments/assets/6209a9ad-4879-465a-a3c7-a661bcc1bf66" />


### 개발 체크리스트

<!--- 아래 목록을 확인하시고 `x` 표시를 해주세요. -->

- [ ] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [ ] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
