### PR TITLE
feat: 투표기능 구현

### DIFF
--- a/src/apis/vote/vote-schema-contract.ts
+++ b/src/apis/vote/vote-schema-contract.ts
@@ -1,0 +1,73 @@
+export const VOTE_TABLES = {
+  ROOMS: 'vote_rooms',
+  ROUNDS: 'vote_rounds',
+  OPTIONS: 'vote_options',
+  PARTICIPANTS: 'vote_participants',
+  BALLOTS: 'vote_ballots',
+} as const;
+
+export type VoteRoomStatus = 'draft' | 'live' | 'ended';
+export type VoteRoundStatus = 'ready' | 'live' | 'ended';
+
+export type VoteRoomRow = {
+  id: string;
+  title: string;
+  status: VoteRoomStatus;
+  currentRoundId: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type VoteRoundRow = {
+  id: string;
+  roomId: string;
+  roundNumber: number;
+  question: string;
+  maxSelections: number;
+  status: VoteRoundStatus;
+  createdAt: string;
+  startedAt: string | null;
+  endedAt: string | null;
+};
+
+export type VoteOptionRow = {
+  id: string;
+  roundId: string;
+  label: string;
+  displayOrder: number;
+  createdAt: string;
+};
+
+export type VoteParticipantRow = {
+  id: string;
+  roomId: string;
+  token: string;
+  name: string;
+  joinedAt: string;
+};
+
+export type VoteBallotRow = {
+  id: string;
+  roomId: string;
+  roundId: string;
+  optionId: string;
+  participantId: string;
+  createdAt: string;
+};
+
+/**
+ * Supabase schema contract:
+ * - vote_participants(roomId, token) UNIQUE
+ * - vote_options(roundId, displayOrder) UNIQUE
+ * - vote_ballots(roundId, participantId, optionId) UNIQUE
+ * - vote_ballots insert는 "round당 participant 1회 제출" 정책을 지키도록
+ *   서버(RLS / trigger / RPC)에서 추가 검증이 필요합니다.
+ */
+export const VOTE_SCHEMA_CONTRACT = {
+  tableNames: VOTE_TABLES,
+  constraints: {
+    uniqueParticipantByRoom: ['roomId', 'token'],
+    uniqueOptionOrderByRound: ['roundId', 'displayOrder'],
+    uniqueBallotByOption: ['roundId', 'participantId', 'optionId'],
+  },
+} as const;

--- a/src/apis/vote/vote.ts
+++ b/src/apis/vote/vote.ts
@@ -1,0 +1,505 @@
+import { supabase } from '@/utils/supabase';
+import {
+  VOTE_TABLES,
+  VoteBallotRow,
+  VoteOptionRow,
+  VoteRoomRow,
+  VoteRoundRow,
+  VoteRoomStatus,
+  VoteRoundStatus,
+} from './vote-schema-contract';
+
+export type VoteOptionResult = VoteOptionRow & {
+  voteCount: number;
+};
+
+export type VoteRoundWithOptions = VoteRoundRow & {
+  options: VoteOptionResult[];
+  totalVotes: number;
+};
+
+export type VoteTeacherSnapshot = {
+  room: VoteRoomRow;
+  joinedStudentCount: number;
+  currentRound: VoteRoundWithOptions | null;
+  rounds: VoteRoundWithOptions[];
+};
+
+type VoteBallotSelectRow = Pick<VoteBallotRow, 'optionId' | 'roundId'>;
+
+export type CreateVoteRoomParams = {
+  title: string;
+};
+
+export type CreateVoteRoundParams = {
+  roomId: string;
+  question: string;
+  maxSelections: number;
+  options: string[];
+};
+
+export type SubmitVoteBallotParams = {
+  roomId: string;
+  roundId: string;
+  optionIds: string[];
+  participantToken: string;
+  participantName: string;
+};
+
+export const createVoteRoom = async ({
+  title,
+}: CreateVoteRoomParams): Promise<{ roomId: string }> => {
+  const { data, error } = await supabase
+    .from(VOTE_TABLES.ROOMS)
+    .insert({
+      title,
+      status: 'draft' as VoteRoomStatus,
+      currentRoundId: null,
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return { roomId: data.id };
+};
+
+const buildRoundResults = (
+  rounds: VoteRoundRow[],
+  options: VoteOptionRow[],
+  ballots: VoteBallotSelectRow[],
+): VoteRoundWithOptions[] => {
+  const ballotCountByOptionId = ballots.reduce<Record<string, number>>(
+    (acc, ballot) => {
+      acc[ballot.optionId] = (acc[ballot.optionId] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+
+  return rounds.map((round) => {
+    const optionsInRound = options
+      .filter((option) => option.roundId === round.id)
+      .sort((a, b) => a.displayOrder - b.displayOrder)
+      .map((option) => ({
+        ...option,
+        voteCount: ballotCountByOptionId[option.id] ?? 0,
+      }));
+
+    const totalVotes = optionsInRound.reduce(
+      (sum, option) => sum + option.voteCount,
+      0,
+    );
+
+    return {
+      ...round,
+      options: optionsInRound,
+      totalVotes,
+    };
+  });
+};
+
+export const getVoteTeacherSnapshot = async ({
+  roomId,
+}: {
+  roomId: string;
+}): Promise<VoteTeacherSnapshot> => {
+  const [
+    { data: room, error: roomError },
+    { count: joinedStudentCount, error },
+  ] = await Promise.all([
+    supabase.from(VOTE_TABLES.ROOMS).select('*').eq('id', roomId).single(),
+    supabase
+      .from(VOTE_TABLES.PARTICIPANTS)
+      .select('id', { count: 'exact', head: true })
+      .eq('roomId', roomId),
+  ]);
+
+  if (roomError) {
+    throw new Error(roomError.message);
+  }
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const { data: rounds, error: roundsError } = await supabase
+    .from(VOTE_TABLES.ROUNDS)
+    .select('*')
+    .eq('roomId', roomId)
+    .order('roundNumber', { ascending: false })
+    .returns<VoteRoundRow[]>();
+
+  if (roundsError) {
+    throw new Error(roundsError.message);
+  }
+
+  if (!rounds || rounds.length === 0) {
+    return {
+      room,
+      joinedStudentCount: joinedStudentCount ?? 0,
+      currentRound: null,
+      rounds: [],
+    };
+  }
+
+  const roundIds = rounds.map((round) => round.id);
+  const [
+    { data: options, error: optionsError },
+    { data: ballots, error: ballotsError },
+  ] = await Promise.all([
+    supabase
+      .from(VOTE_TABLES.OPTIONS)
+      .select('*')
+      .in('roundId', roundIds)
+      .returns<VoteOptionRow[]>(),
+    supabase
+      .from(VOTE_TABLES.BALLOTS)
+      .select('optionId, roundId')
+      .in('roundId', roundIds)
+      .returns<VoteBallotSelectRow[]>(),
+  ]);
+
+  if (optionsError) {
+    throw new Error(optionsError.message);
+  }
+
+  if (ballotsError) {
+    throw new Error(ballotsError.message);
+  }
+
+  const roundResults = buildRoundResults(rounds, options ?? [], ballots ?? []);
+  const currentRound =
+    roundResults.find((round) => round.id === room.currentRoundId) ??
+    roundResults[0] ??
+    null;
+
+  return {
+    room,
+    joinedStudentCount: joinedStudentCount ?? 0,
+    currentRound,
+    rounds: roundResults,
+  };
+};
+
+export const createVoteRound = async ({
+  roomId,
+  question,
+  maxSelections,
+  options,
+}: CreateVoteRoundParams): Promise<{ roundId: string }> => {
+  const trimmedOptions = options.map((option) => option.trim()).filter(Boolean);
+  if (trimmedOptions.length < 2) {
+    throw new Error('선택지는 최소 2개 이상 필요합니다.');
+  }
+
+  if (trimmedOptions.length > 50) {
+    throw new Error('선택지는 최대 50개까지 만들 수 있습니다.');
+  }
+
+  const { data: latestRound } = await supabase
+    .from(VOTE_TABLES.ROUNDS)
+    .select('roundNumber')
+    .eq('roomId', roomId)
+    .order('roundNumber', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const nextRoundNumber = (latestRound?.roundNumber ?? 0) + 1;
+
+  const { data: round, error: roundError } = await supabase
+    .from(VOTE_TABLES.ROUNDS)
+    .insert({
+      roomId,
+      question,
+      maxSelections,
+      roundNumber: nextRoundNumber,
+      status: 'ready' as VoteRoundStatus,
+    })
+    .select('id')
+    .single();
+
+  if (roundError) {
+    throw new Error(roundError.message);
+  }
+
+  const { error: optionError } = await supabase
+    .from(VOTE_TABLES.OPTIONS)
+    .insert(
+      trimmedOptions.map((option, index) => ({
+        roundId: round.id,
+        label: option,
+        displayOrder: index + 1,
+      })),
+    );
+
+  if (optionError) {
+    throw new Error(optionError.message);
+  }
+
+  const { error: roomUpdateError } = await supabase
+    .from(VOTE_TABLES.ROOMS)
+    .update({
+      status: 'draft' as VoteRoomStatus,
+      currentRoundId: round.id,
+    })
+    .eq('id', roomId);
+
+  if (roomUpdateError) {
+    throw new Error(roomUpdateError.message);
+  }
+
+  return { roundId: round.id };
+};
+
+export const startVoteRound = async ({
+  roomId,
+  roundId,
+}: {
+  roomId: string;
+  roundId: string;
+}) => {
+  const startedAt = new Date().toISOString();
+
+  const [{ error: roundError }, { error: roomError }] = await Promise.all([
+    supabase
+      .from(VOTE_TABLES.ROUNDS)
+      .update({
+        status: 'live' as VoteRoundStatus,
+        startedAt,
+        endedAt: null,
+      })
+      .eq('id', roundId),
+    supabase
+      .from(VOTE_TABLES.ROOMS)
+      .update({
+        status: 'live' as VoteRoomStatus,
+        currentRoundId: roundId,
+      })
+      .eq('id', roomId),
+  ]);
+
+  if (roundError) {
+    throw new Error(roundError.message);
+  }
+
+  if (roomError) {
+    throw new Error(roomError.message);
+  }
+};
+
+export const endVoteRound = async ({ roundId }: { roundId: string }) => {
+  const { error } = await supabase
+    .from(VOTE_TABLES.ROUNDS)
+    .update({
+      status: 'ended' as VoteRoundStatus,
+      endedAt: new Date().toISOString(),
+    })
+    .eq('id', roundId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+};
+
+export const finishVoteRoom = async ({ roomId }: { roomId: string }) => {
+  const { error } = await supabase
+    .from(VOTE_TABLES.ROOMS)
+    .update({
+      status: 'ended' as VoteRoomStatus,
+    })
+    .eq('id', roomId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+};
+
+export const joinVoteRoomParticipant = async ({
+  roomId,
+  token,
+  name,
+}: {
+  roomId: string;
+  token: string;
+  name: string;
+}) => {
+  const { data: existingParticipant, error: fetchError } = await supabase
+    .from(VOTE_TABLES.PARTICIPANTS)
+    .select('id')
+    .eq('roomId', roomId)
+    .eq('token', token)
+    .maybeSingle();
+
+  if (fetchError) {
+    throw new Error(fetchError.message);
+  }
+
+  if (existingParticipant) {
+    const { error: updateError } = await supabase
+      .from(VOTE_TABLES.PARTICIPANTS)
+      .update({ name })
+      .eq('id', existingParticipant.id);
+
+    if (updateError) {
+      throw new Error(updateError.message);
+    }
+
+    return { participantId: existingParticipant.id };
+  }
+
+  const { data, error } = await supabase
+    .from(VOTE_TABLES.PARTICIPANTS)
+    .insert({
+      roomId,
+      token,
+      name,
+      joinedAt: new Date().toISOString(),
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return { participantId: data.id };
+};
+
+export const getVoteStudentSnapshot = async ({
+  roomId,
+  participantToken,
+}: {
+  roomId: string;
+  participantToken: string;
+}) => {
+  const { data: room, error: roomError } = await supabase
+    .from(VOTE_TABLES.ROOMS)
+    .select('id, title, currentRoundId')
+    .eq('id', roomId)
+    .single();
+
+  if (roomError) {
+    throw new Error(roomError.message);
+  }
+
+  if (!room.currentRoundId) {
+    return {
+      roomTitle: room.title,
+      liveRound: null,
+      alreadySubmitted: false,
+    };
+  }
+
+  const { data: round, error: roundError } = await supabase
+    .from(VOTE_TABLES.ROUNDS)
+    .select('*')
+    .eq('id', room.currentRoundId)
+    .single();
+
+  if (roundError) {
+    throw new Error(roundError.message);
+  }
+
+  if (round.status !== 'live') {
+    return {
+      roomTitle: room.title,
+      liveRound: null,
+      alreadySubmitted: false,
+    };
+  }
+
+  const [{ data: options, error: optionError }, { data: participant }] =
+    await Promise.all([
+      supabase
+        .from(VOTE_TABLES.OPTIONS)
+        .select('*')
+        .eq('roundId', round.id)
+        .order('displayOrder', { ascending: true })
+        .returns<VoteOptionRow[]>(),
+      supabase
+        .from(VOTE_TABLES.PARTICIPANTS)
+        .select('id')
+        .eq('roomId', roomId)
+        .eq('token', participantToken)
+        .maybeSingle(),
+    ]);
+
+  if (optionError) {
+    throw new Error(optionError.message);
+  }
+
+  let alreadySubmitted = false;
+  if (participant) {
+    const { count, error: ballotError } = await supabase
+      .from(VOTE_TABLES.BALLOTS)
+      .select('id', { count: 'exact', head: true })
+      .eq('roundId', round.id)
+      .eq('participantId', participant.id);
+
+    if (ballotError) {
+      throw new Error(ballotError.message);
+    }
+
+    alreadySubmitted = (count ?? 0) > 0;
+  }
+
+  return {
+    roomTitle: room.title,
+    liveRound: {
+      ...round,
+      options: options ?? [],
+    },
+    alreadySubmitted,
+  };
+};
+
+export const submitVoteBallot = async ({
+  roomId,
+  roundId,
+  optionIds,
+  participantToken,
+  participantName,
+}: SubmitVoteBallotParams) => {
+  if (optionIds.length === 0) {
+    throw new Error('최소 1개 이상의 선택지를 선택해주세요.');
+  }
+
+  const { participantId } = await joinVoteRoomParticipant({
+    roomId,
+    token: participantToken,
+    name: participantName,
+  });
+
+  const { count, error: countError } = await supabase
+    .from(VOTE_TABLES.BALLOTS)
+    .select('id', { count: 'exact', head: true })
+    .eq('roundId', roundId)
+    .eq('participantId', participantId);
+
+  if (countError) {
+    throw new Error(countError.message);
+  }
+
+  if ((count ?? 0) > 0) {
+    throw new Error('이미 해당 라운드에 투표를 완료했습니다.');
+  }
+
+  const { error: ballotError } = await supabase
+    .from(VOTE_TABLES.BALLOTS)
+    .insert(
+      optionIds.map((optionId) => ({
+        roomId,
+        roundId,
+        optionId,
+        participantId,
+        createdAt: new Date().toISOString(),
+      })),
+    );
+
+  if (ballotError) {
+    throw new Error(ballotError.message);
+  }
+};

--- a/src/apis/vote/vote.ts
+++ b/src/apis/vote/vote.ts
@@ -38,6 +38,14 @@ export type CreateVoteRoundParams = {
   options: string[];
 };
 
+export type UpdateReadyVoteRoundParams = {
+  roomId: string;
+  roundId: string;
+  question: string;
+  maxSelections: number;
+  options: string[];
+};
+
 export type SubmitVoteBallotParams = {
   roomId: string;
   roundId: string;
@@ -256,6 +264,83 @@ export const createVoteRound = async ({
   }
 
   return { roundId: round.id };
+};
+
+export const updateReadyVoteRound = async ({
+  roomId,
+  roundId,
+  question,
+  maxSelections,
+  options,
+}: UpdateReadyVoteRoundParams): Promise<{ roundId: string }> => {
+  const trimmedOptions = options.map((option) => option.trim()).filter(Boolean);
+  if (trimmedOptions.length < 2) {
+    throw new Error('선택지는 최소 2개 이상 필요합니다.');
+  }
+
+  if (trimmedOptions.length > MAX_VOTE_OPTIONS) {
+    throw new Error(
+      `선택지는 최대 ${MAX_VOTE_OPTIONS}개까지 만들 수 있습니다.`,
+    );
+  }
+
+  if (maxSelections > trimmedOptions.length - 1) {
+    throw new Error(
+      '최대 선택 개수는 유효한 선택지 개수보다 1개 적어야 합니다.',
+    );
+  }
+
+  const { data: targetRound, error: targetRoundError } = await supabase
+    .from(VOTE_TABLES.ROUNDS)
+    .select('id, status')
+    .eq('id', roundId)
+    .eq('roomId', roomId)
+    .single();
+
+  if (targetRoundError) {
+    throw new Error(targetRoundError.message);
+  }
+
+  if (targetRound.status !== 'ready') {
+    throw new Error('준비 상태의 투표만 수정할 수 있습니다.');
+  }
+
+  const { error: roundUpdateError } = await supabase
+    .from(VOTE_TABLES.ROUNDS)
+    .update({
+      question,
+      maxSelections,
+    })
+    .eq('id', roundId);
+
+  if (roundUpdateError) {
+    throw new Error(roundUpdateError.message);
+  }
+
+  const { error: deleteOptionError } = await supabase
+    .from(VOTE_TABLES.OPTIONS)
+    .delete()
+    .eq('roundId', roundId);
+
+  if (deleteOptionError) {
+    throw new Error(deleteOptionError.message);
+  }
+
+  const { error: insertOptionError } = await supabase
+    .from(VOTE_TABLES.OPTIONS)
+    .insert(
+      trimmedOptions.map((option, index) => ({
+        roundId,
+        label: option,
+        displayOrder: index + 1,
+      })),
+    );
+
+  if (insertOptionError) {
+    throw new Error(insertOptionError.message);
+  }
+
+  return { roundId };
 };
 
 export const startVoteRound = async ({

--- a/src/apis/vote/vote.ts
+++ b/src/apis/vote/vote.ts
@@ -46,6 +46,8 @@ export type SubmitVoteBallotParams = {
   participantName: string;
 };
 
+const MAX_VOTE_OPTIONS = 10;
+
 const buildRoundResults = (
   rounds: VoteRoundRow[],
   options: VoteOptionRow[],
@@ -195,8 +197,10 @@ export const createVoteRound = async ({
     throw new Error('선택지는 최소 2개 이상 필요합니다.');
   }
 
-  if (trimmedOptions.length > 50) {
-    throw new Error('선택지는 최대 50개까지 만들 수 있습니다.');
+  if (trimmedOptions.length > MAX_VOTE_OPTIONS) {
+    throw new Error(
+      `선택지는 최대 ${MAX_VOTE_OPTIONS}개까지 만들 수 있습니다.`,
+    );
   }
 
   const { data: latestRound } = await supabase

--- a/src/apis/vote/vote.ts
+++ b/src/apis/vote/vote.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/utils/supabase';
+import { supabaseVote as supabase } from '@/utils/supabase';
 import {
   VOTE_TABLES,
   VoteBallotRow,
@@ -46,26 +46,6 @@ export type SubmitVoteBallotParams = {
   participantName: string;
 };
 
-export const createVoteRoom = async ({
-  title,
-}: CreateVoteRoomParams): Promise<{ roomId: string }> => {
-  const { data, error } = await supabase
-    .from(VOTE_TABLES.ROOMS)
-    .insert({
-      title,
-      status: 'draft' as VoteRoomStatus,
-      currentRoundId: null,
-    })
-    .select('id')
-    .single();
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  return { roomId: data.id };
-};
-
 const buildRoundResults = (
   rounds: VoteRoundRow[],
   options: VoteOptionRow[],
@@ -99,6 +79,26 @@ const buildRoundResults = (
       totalVotes,
     };
   });
+};
+
+export const createVoteRoom = async ({
+  title,
+}: CreateVoteRoomParams): Promise<{ roomId: string }> => {
+  const { data, error } = await supabase
+    .from(VOTE_TABLES.ROOMS)
+    .insert({
+      title,
+      status: 'draft' as VoteRoomStatus,
+      currentRoundId: null,
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return { roomId: data.id };
 };
 
 export const getVoteTeacherSnapshot = async ({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,12 @@ const pyeongtaek = localFont({
 });
 
 const isMinimalLayoutPages = {
-  startsWith: ['/timer', '/music-request/student/', '/routine-timer/play'],
+  startsWith: [
+    '/timer',
+    '/music-request/student/',
+    '/vote/student/',
+    '/routine-timer/play',
+  ],
   equal: [MENU_ROUTE.NOTICE],
 };
 

--- a/src/app/vote/page.tsx
+++ b/src/app/vote/page.tsx
@@ -1,0 +1,9 @@
+import VoteContainer from '@/containers/vote/vote-container';
+
+export const metadata = {
+  title: '투표하기',
+};
+
+export default function VotePage() {
+  return <VoteContainer />;
+}

--- a/src/app/vote/student/[roomId]/page.tsx
+++ b/src/app/vote/student/[roomId]/page.tsx
@@ -1,4 +1,6 @@
 import VoteStudentContainer from '@/containers/vote/vote-student/vote-student-container';
+import { normalizeVoteRoomId } from '@/containers/vote/vote-room-id';
+import { redirect } from 'next/navigation';
 
 export const metadata = {
   title: '투표하기',
@@ -9,5 +11,11 @@ export default function VoteStudentPage({
 }: {
   params: { roomId: string };
 }) {
-  return <VoteStudentContainer params={params} />;
+  const normalizedRoomId = normalizeVoteRoomId(params.roomId);
+
+  if (normalizedRoomId !== params.roomId) {
+    redirect(`/vote/student/${normalizedRoomId}`);
+  }
+
+  return <VoteStudentContainer params={{ roomId: normalizedRoomId }} />;
 }

--- a/src/app/vote/student/[roomId]/page.tsx
+++ b/src/app/vote/student/[roomId]/page.tsx
@@ -1,0 +1,13 @@
+import VoteStudentContainer from '@/containers/vote/vote-student/vote-student-container';
+
+export const metadata = {
+  title: '투표하기',
+};
+
+export default function VoteStudentPage({
+  params,
+}: {
+  params: { roomId: string };
+}) {
+  return <VoteStudentContainer params={params} />;
+}

--- a/src/app/vote/teacher/[roomId]/page.tsx
+++ b/src/app/vote/teacher/[roomId]/page.tsx
@@ -1,4 +1,6 @@
 import VoteTeacherContainer from '@/containers/vote/vote-teacher/vote-teacher-container';
+import { normalizeVoteRoomId } from '@/containers/vote/vote-room-id';
+import { redirect } from 'next/navigation';
 
 export const metadata = {
   title: '투표하기',
@@ -9,5 +11,11 @@ export default function VoteTeacherPage({
 }: {
   params: { roomId: string };
 }) {
-  return <VoteTeacherContainer params={params} />;
+  const normalizedRoomId = normalizeVoteRoomId(params.roomId);
+
+  if (normalizedRoomId !== params.roomId) {
+    redirect(`/vote/teacher/${normalizedRoomId}`);
+  }
+
+  return <VoteTeacherContainer params={{ roomId: normalizedRoomId }} />;
 }

--- a/src/app/vote/teacher/[roomId]/page.tsx
+++ b/src/app/vote/teacher/[roomId]/page.tsx
@@ -1,0 +1,13 @@
+import VoteTeacherContainer from '@/containers/vote/vote-teacher/vote-teacher-container';
+
+export const metadata = {
+  title: '투표하기',
+};
+
+export default function VoteTeacherPage({
+  params,
+}: {
+  params: { roomId: string };
+}) {
+  return <VoteTeacherContainer params={params} />;
+}

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -13,6 +13,7 @@ const buttonVariants = cva(
           'bg-primary text-primary-foreground fill-primary-foreground hover:bg-primary/90 active:bg-primary-600',
         secondary:
           'bg-secondary text-secondary-foreground fill-secondary-foreground hover:bg-secondary/90 active:bg-secondary-600',
+        gray: 'bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 fill-gray-900 dark:fill-gray-100 hover:bg-gray-100 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500',
         red: 'bg-red text-red-foreground hover:bg-red/90 active:bg-red-600',
 
         'primary-outline':

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -18,6 +18,7 @@ import {
   FileTextIcon,
   Hourglass,
   UnfoldHorizontal,
+  VoteIcon,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
@@ -64,6 +65,11 @@ const breadcrumbs: Record<
     name: '음악신청',
     url: '/music-request',
     icon: <MusicIcon size="1rem" />,
+  },
+  vote: {
+    name: '투표하기',
+    url: '/vote',
+    icon: <VoteIcon size="1rem" />,
   },
   feedback: {
     name: '피드백',

--- a/src/constants/localStorageGroups.ts
+++ b/src/constants/localStorageGroups.ts
@@ -65,6 +65,14 @@ export const LOCAL_STORAGE_KEY_META: Record<
     label: '음악 신청 방 목록',
     description: '음악 신청에서 사용하는 방(교실) ID 목록입니다.',
   },
+  'vote-room-ids': {
+    label: '투표 방 목록',
+    description: '투표하기에서 저장한 투표 방 ID 목록입니다.',
+  },
+  'vote-active-room-id': {
+    label: '진행 중 투표 방',
+    description: '투표하기에서 복구 가능한 진행 중 방 ID입니다.',
+  },
   routines: {
     label: '루틴 목록',
     description: '루틴 타이머에 저장한 루틴 목록입니다.',
@@ -117,6 +125,11 @@ export const LOCAL_STORAGE_GROUPS = [
     id: 'music-request',
     label: '음악신청',
     keys: ['roomIds'],
+  },
+  {
+    id: 'vote',
+    label: '투표하기',
+    keys: ['vote-room-ids', 'vote-active-room-id'],
   },
   {
     id: 'routine-timer',

--- a/src/constants/localStorageGroups.ts
+++ b/src/constants/localStorageGroups.ts
@@ -65,14 +65,6 @@ export const LOCAL_STORAGE_KEY_META: Record<
     label: '음악 신청 방 목록',
     description: '음악 신청에서 사용하는 방(교실) ID 목록입니다.',
   },
-  'vote-room-ids': {
-    label: '투표 방 목록',
-    description: '투표하기에서 저장한 투표 방 ID 목록입니다.',
-  },
-  'vote-active-room-id': {
-    label: '진행 중 투표 방',
-    description: '투표하기에서 복구 가능한 진행 중 방 ID입니다.',
-  },
   routines: {
     label: '루틴 목록',
     description: '루틴 타이머에 저장한 루틴 목록입니다.',
@@ -125,11 +117,6 @@ export const LOCAL_STORAGE_GROUPS = [
     id: 'music-request',
     label: '음악신청',
     keys: ['roomIds'],
-  },
-  {
-    id: 'vote',
-    label: '투표하기',
-    keys: ['vote-room-ids', 'vote-active-room-id'],
   },
   {
     id: 'routine-timer',

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -12,6 +12,7 @@ import {
   WandSparklesIcon,
   MegaphoneIcon,
   CircleDotIcon,
+  VoteIcon,
   SplitIcon,
   ClockIcon,
   WatchIcon,
@@ -36,6 +37,7 @@ export const MENU_ROUTE = {
   ROUTINE_TIMER: '/routine-timer',
   ROULETTE: '/roulette',
   RANDOM_TEAM: '/random-team',
+  VOTE: '/vote',
 } as const;
 
 // NOTE:(김홍동) 수업도구 전용 라우트 (메뉴와 분리하여 관리)
@@ -107,6 +109,12 @@ export const MENU_PATH_DATA: PathData<MenuRoutePath> = {
       { title: '아날로그', href: `${MENU_ROUTE.CLOCK}/analog` },
       { title: '디지털', href: `${MENU_ROUTE.CLOCK}/digital` },
     ],
+  },
+  '/vote': {
+    title: '투표하기',
+    Icon: VoteIcon,
+    href: MENU_ROUTE.VOTE,
+    isNew: true,
   },
   '/stopwatch': {
     title: '스톱워치',

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -10,9 +10,9 @@ import {
   DatabaseIcon,
   TimerIcon,
   WandSparklesIcon,
-  MegaphoneIcon,
+  // MegaphoneIcon,
   CircleDotIcon,
-  VoteIcon,
+  // VoteIcon,
   SplitIcon,
   ClockIcon,
   WatchIcon,
@@ -110,12 +110,12 @@ export const MENU_PATH_DATA: PathData<MenuRoutePath> = {
       { title: '디지털', href: `${MENU_ROUTE.CLOCK}/digital` },
     ],
   },
-  '/vote': {
-    title: '투표하기',
-    Icon: VoteIcon,
-    href: MENU_ROUTE.VOTE,
-    isNew: true,
-  },
+  // '/vote': {
+  //   title: '투표하기',
+  //   Icon: VoteIcon,
+  //   href: MENU_ROUTE.VOTE,
+  //   isNew: true,
+  // },
   '/stopwatch': {
     title: '스톱워치',
     Icon: WatchIcon,
@@ -195,11 +195,11 @@ export const DATA_PATH_DATA: PathData<DataRoutePath> = {
 
 // NOTE:(김홍동) 네비게이션의 도움 영역에서 사용되는 객체입니다.
 export const HELP_PATH_DATA: PathData<HelpRoutePath> = {
-  '/announcement': {
-    title: '공지사항',
-    Icon: MegaphoneIcon,
-    href: HELP_ROUTE.ANNOUNCEMENT,
-  },
+  // '/announcement': {
+  //   title: '공지사항',
+  //   Icon: MegaphoneIcon,
+  //   href: HELP_ROUTE.ANNOUNCEMENT,
+  // },
   '/feedback': {
     title: '피드백',
     Icon: MessageCircleHeartIcon,

--- a/src/containers/vote/vote-constants.ts
+++ b/src/containers/vote/vote-constants.ts
@@ -1,6 +1,1 @@
-export const VOTE_LOCAL_STORAGE_KEYS = {
-  ROOM_IDS: 'vote-room-ids',
-  ACTIVE_ROOM_ID: 'vote-active-room-id',
-} as const;
-
 export const MAX_VOTE_OPTIONS = 50;

--- a/src/containers/vote/vote-constants.ts
+++ b/src/containers/vote/vote-constants.ts
@@ -1,1 +1,1 @@
-export const MAX_VOTE_OPTIONS = 50;
+export const MAX_VOTE_OPTIONS = 10;

--- a/src/containers/vote/vote-constants.ts
+++ b/src/containers/vote/vote-constants.ts
@@ -1,0 +1,6 @@
+export const VOTE_LOCAL_STORAGE_KEYS = {
+  ROOM_IDS: 'vote-room-ids',
+  ACTIVE_ROOM_ID: 'vote-active-room-id',
+} as const;
+
+export const MAX_VOTE_OPTIONS = 50;

--- a/src/containers/vote/vote-container.tsx
+++ b/src/containers/vote/vote-container.tsx
@@ -130,7 +130,7 @@ export default function VoteContainer() {
               handleCreateRoom();
             }
           }}
-          placeholder="투표 제목을 입력하세요."
+          placeholder="제목을 입력하세요."
           className="h-12 text-lg"
         />
         <Button
@@ -142,7 +142,7 @@ export default function VoteContainer() {
           {isPending ? (
             <LoaderCircle className="size-5 text-white animate-spin" />
           ) : (
-            '만들기'
+            '시작하기'
           )}
         </Button>
       </div>

--- a/src/containers/vote/vote-container.tsx
+++ b/src/containers/vote/vote-container.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Plus, LoaderCircle, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/button';
+import { Input } from '@/components/input';
+import { Heading1 } from '@/components/heading';
+import { Skeleton } from '@/components/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/dialog';
+import useLocalStorage from '@/hooks/useLocalStorage';
+import { useCreateVoteRoom } from '@/hooks/apis/vote/use-create-vote-room';
+import { useGetVoteTeacherSnapshots } from '@/hooks/apis/vote/use-get-vote-snapshot';
+import { VOTE_LOCAL_STORAGE_KEYS } from './vote-constants';
+
+export default function VoteContainer() {
+  const router = useRouter();
+  const [roomTitle, setRoomTitle] = useState('');
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [showRestoreModal, setShowRestoreModal] = useState(true);
+  const [roomIds, setRoomIds] = useLocalStorage<string[]>(
+    VOTE_LOCAL_STORAGE_KEYS.ROOM_IDS,
+    [],
+  );
+  const [activeRoomId, setActiveRoomId] = useLocalStorage<string>(
+    VOTE_LOCAL_STORAGE_KEYS.ACTIVE_ROOM_ID,
+    '',
+  );
+  const { mutate: createVoteRoomMutation, isPending } = useCreateVoteRoom();
+  const snapshotQueries = useGetVoteTeacherSnapshots(roomIds ?? []);
+
+  const hasPendingRestore = Boolean(activeRoomId) && showRestoreModal;
+  const hasLoadingRoom = snapshotQueries.some((query) => query.isLoading);
+
+  const handleCreateRoom = () => {
+    const title = roomTitle.trim();
+    if (!title) return;
+
+    createVoteRoomMutation(
+      { title },
+      {
+        onSuccess: ({ roomId }) => {
+          setRoomIds((prev) =>
+            prev.includes(roomId) ? prev : [...prev, roomId],
+          );
+          setActiveRoomId(roomId);
+          setIsCreateModalOpen(false);
+          setRoomTitle('');
+          router.push(`/vote/teacher/${roomId}`);
+        },
+      },
+    );
+  };
+
+  const voteRooms = snapshotQueries
+    .map((query, index) => {
+      if (!query.data) return null;
+      return {
+        roomId: roomIds[index],
+        title: query.data.room.title,
+        status: query.data.room.status,
+        currentRound: query.data.currentRound,
+      };
+    })
+    .filter((room): room is NonNullable<typeof room> => room !== null);
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-6">
+        <Heading1 className="mb-0">투표하기</Heading1>
+        <Button
+          variant="primary-ghost"
+          size="sm"
+          onClick={() => {
+            setRoomIds([]);
+            setActiveRoomId('');
+          }}
+        >
+          투표 목록 초기화
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {hasLoadingRoom
+          ? Array.from({ length: 3 }).map((_, index) => (
+              <Skeleton
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                className="w-full aspect-video rounded-md"
+              />
+            ))
+          : voteRooms.map((room) => (
+              <button
+                type="button"
+                key={room.roomId}
+                className="aspect-video rounded-md border dark:border-gray-700 p-4 text-left flex flex-col justify-between hover:bg-gray-50 dark:hover:bg-gray-900"
+                onClick={() => {
+                  setActiveRoomId(room.roomId);
+                  router.push(`/vote/teacher/${room.roomId}`);
+                }}
+              >
+                <div className="text-lg font-semibold text-text-title line-clamp-2">
+                  {room.title}
+                </div>
+                <div className="text-sm text-text-subtitle">
+                  <div>
+                    상태:{' '}
+                    {room.status === 'live'
+                      ? '진행 중'
+                      : room.status === 'ended'
+                        ? '종료됨'
+                        : '준비 중'}
+                  </div>
+                  <div className="line-clamp-1">
+                    질문: {room.currentRound?.question ?? '아직 없음'}
+                  </div>
+                </div>
+                <div className="text-primary flex items-center gap-1 text-sm">
+                  방 입장하기
+                  <ChevronRight className="size-4" />
+                </div>
+              </button>
+            ))}
+
+        <button
+          type="button"
+          className="aspect-video rounded-md border-2 border-dashed border-primary-300 text-primary flex items-center justify-center hover:bg-primary-50 dark:hover:bg-gray-900"
+          onClick={() => setIsCreateModalOpen(true)}
+        >
+          <Plus className="size-8" />
+        </button>
+      </div>
+
+      <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>투표방 만들기</DialogTitle>
+            <DialogDescription className="pt-4 space-y-4">
+              <Input
+                value={roomTitle}
+                onChange={(event) => setRoomTitle(event.target.value)}
+                placeholder="투표 제목을 입력해주세요."
+              />
+              <div className="flex justify-end">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleCreateRoom}
+                  disabled={!roomTitle.trim() || isPending}
+                >
+                  {isPending ? (
+                    <LoaderCircle className="size-4 text-white animate-spin" />
+                  ) : (
+                    '방 만들기'
+                  )}
+                </Button>
+              </div>
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={hasPendingRestore} onOpenChange={setShowRestoreModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>진행 중인 투표가 있어요</DialogTitle>
+            <DialogDescription className="pt-4 text-sm text-text-subtitle">
+              이전에 진행하던 투표를 계속할지, 초기화하고 새로 시작할지
+              선택해주세요.
+            </DialogDescription>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="gray-ghost"
+                size="sm"
+                onClick={() => {
+                  setActiveRoomId('');
+                  setShowRestoreModal(false);
+                }}
+              >
+                초기화하고 새로 만들기
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => {
+                  setShowRestoreModal(false);
+                  router.push(`/vote/teacher/${activeRoomId}`);
+                }}
+              >
+                계속하기
+              </Button>
+            </div>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/containers/vote/vote-container.tsx
+++ b/src/containers/vote/vote-container.tsx
@@ -53,61 +53,61 @@ export default function VoteContainer() {
 
       <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
         <div className="rounded-xl bg-primary-50 dark:bg-primary-900/20 px-3.5 py-3">
-          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+          <div className="flex items-center gap-2 text-sm font-semibold text-text-title">
             <Vote className="size-4 text-primary" />
             빠른 시작
           </div>
-          <p className="mt-1 text-sm text-text-subtitle">
+          <p className="mt-1 text-xs text-text-subtitle">
             옵션 설정 후 즉시 투표를 시작할 수 있습니다.
           </p>
         </div>
 
         <div className="rounded-xl bg-blue-50 dark:bg-blue-900/20 px-3.5 py-3">
-          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+          <div className="flex items-center gap-2 text-sm font-semibold text-text-title">
             <QrCode className="size-4 text-blue-500" />
             쉬운 참여
           </div>
-          <p className="mt-1 text-sm text-text-subtitle">
+          <p className="mt-1 text-xs text-text-subtitle">
             링크/QR로 학생을 바로 초대할 수 있습니다.
           </p>
         </div>
 
         <div className="rounded-xl bg-emerald-50 dark:bg-emerald-900/20 px-3.5 py-3">
-          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+          <div className="flex items-center gap-2 text-sm font-semibold text-text-title">
             <RefreshCw className="size-4 text-emerald-500" />
             재투표 지원
           </div>
-          <p className="mt-1 text-sm text-text-subtitle">
+          <p className="mt-1 text-xs text-text-subtitle">
             종료 후 선택지를 골라 다시 투표를 만들 수 있습니다.
           </p>
         </div>
 
         <div className="rounded-xl bg-violet-50 dark:bg-violet-900/20 px-3.5 py-3">
-          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+          <div className="flex items-center gap-2 text-sm font-semibold text-text-title">
             <BarChart3 className="size-4 text-violet-500" />
             결과 분석
           </div>
-          <p className="mt-1 text-sm text-text-subtitle">
+          <p className="mt-1 text-xs text-text-subtitle">
             실시간 집계와 최종 결과를 바로 확인합니다.
           </p>
         </div>
 
         <div className="rounded-xl bg-cyan-50 dark:bg-cyan-900/20 px-3.5 py-3">
-          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+          <div className="flex items-center gap-2 text-sm font-semibold text-text-title">
             <Users2 className="size-4 text-cyan-500" />
             실시간 동기화
           </div>
-          <p className="mt-1 text-sm text-text-subtitle">
+          <p className="mt-1 text-xs text-text-subtitle">
             참여, 시작, 결과가 즉시 반영됩니다.
           </p>
         </div>
 
         <div className="rounded-xl bg-amber-50 dark:bg-amber-900/20 px-3.5 py-3">
-          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+          <div className="flex items-center gap-2 text-sm font-semibold text-text-title">
             <Timer className="size-4 text-amber-500" />
             진행 제어
           </div>
-          <p className="mt-1 text-sm text-text-subtitle">
+          <p className="mt-1 text-xs text-text-subtitle">
             교사가 시작/종료를 제어합니다.
           </p>
         </div>
@@ -148,7 +148,8 @@ export default function VoteContainer() {
       </div>
       <ul className="list-disc pl-5 space-y-1 text-xs leading-relaxed text-text-subtitle">
         <li>투표방 목록은 제공하지 않습니다.</li>
-        <li>생성한 투표방은 목록으로 재사용되지 않습니다.</li>
+        <li>이전 투표방 자동 재입장 기능은 지원하지 않습니다.</li>
+        <li>종료된 투표는 다시 시작할 수 없으며, 새로 만들어야 합니다.</li>
         <li>다시 접속하려면 방 주소를 별도로 보관해주세요.</li>
       </ul>
     </div>

--- a/src/containers/vote/vote-container.tsx
+++ b/src/containers/vote/vote-container.tsx
@@ -2,41 +2,25 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Plus, LoaderCircle, ChevronRight } from 'lucide-react';
+import {
+  BarChart3,
+  LoaderCircle,
+  QrCode,
+  RefreshCw,
+  Sparkles,
+  Timer,
+  Users2,
+  Vote,
+} from 'lucide-react';
 import { Button } from '@/components/button';
 import { Input } from '@/components/input';
 import { Heading1 } from '@/components/heading';
-import { Skeleton } from '@/components/skeleton';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/dialog';
-import useLocalStorage from '@/hooks/useLocalStorage';
 import { useCreateVoteRoom } from '@/hooks/apis/vote/use-create-vote-room';
-import { useGetVoteTeacherSnapshots } from '@/hooks/apis/vote/use-get-vote-snapshot';
-import { VOTE_LOCAL_STORAGE_KEYS } from './vote-constants';
 
 export default function VoteContainer() {
   const router = useRouter();
   const [roomTitle, setRoomTitle] = useState('');
-  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [showRestoreModal, setShowRestoreModal] = useState(true);
-  const [roomIds, setRoomIds] = useLocalStorage<string[]>(
-    VOTE_LOCAL_STORAGE_KEYS.ROOM_IDS,
-    [],
-  );
-  const [activeRoomId, setActiveRoomId] = useLocalStorage<string>(
-    VOTE_LOCAL_STORAGE_KEYS.ACTIVE_ROOM_ID,
-    '',
-  );
   const { mutate: createVoteRoomMutation, isPending } = useCreateVoteRoom();
-  const snapshotQueries = useGetVoteTeacherSnapshots(roomIds ?? []);
-
-  const hasPendingRestore = Boolean(activeRoomId) && showRestoreModal;
-  const hasLoadingRoom = snapshotQueries.some((query) => query.isLoading);
 
   const handleCreateRoom = () => {
     const title = roomTitle.trim();
@@ -46,11 +30,6 @@ export default function VoteContainer() {
       { title },
       {
         onSuccess: ({ roomId }) => {
-          setRoomIds((prev) =>
-            prev.includes(roomId) ? prev : [...prev, roomId],
-          );
-          setActiveRoomId(roomId);
-          setIsCreateModalOpen(false);
           setRoomTitle('');
           router.push(`/vote/teacher/${roomId}`);
         },
@@ -58,147 +37,120 @@ export default function VoteContainer() {
     );
   };
 
-  const voteRooms = snapshotQueries
-    .map((query, index) => {
-      if (!query.data) return null;
-      return {
-        roomId: roomIds[index],
-        title: query.data.room.title,
-        status: query.data.room.status,
-        currentRound: query.data.currentRound,
-      };
-    })
-    .filter((room): room is NonNullable<typeof room> => room !== null);
-
   return (
-    <>
-      <div className="flex items-center justify-between mb-6">
-        <Heading1 className="mb-0">투표하기</Heading1>
-        <Button
-          variant="primary-ghost"
-          size="sm"
-          onClick={() => {
-            setRoomIds([]);
-            setActiveRoomId('');
+    <div className="flex-grow flex flex-col gap-y-5 text-text-title w-full max-w-screen-sm mx-auto">
+      <div className="rounded-2xl border border-primary-200/60 bg-gradient-to-br from-primary-50 via-white to-blue-50 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900 px-5 py-6">
+        <div className="inline-flex items-center gap-1.5 rounded-full bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-200 px-3 py-1 text-xs font-semibold">
+          <Sparkles className="size-3.5" />
+          실시간 클래스 투표
+        </div>
+        <Heading1 className="mt-3">투표하기</Heading1>
+        <p className="mt-2 text-sm text-text-subtitle leading-relaxed">
+          질문과 선택지를 만들고 학생을 초대하면, 투표 진행과 결과를 실시간으로
+          확인할 수 있어요.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+        <div className="rounded-xl bg-primary-50 dark:bg-primary-900/20 px-3.5 py-3">
+          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+            <Vote className="size-4 text-primary" />
+            빠른 시작
+          </div>
+          <p className="mt-1 text-sm text-text-subtitle">
+            옵션 설정 후 즉시 투표를 시작할 수 있습니다.
+          </p>
+        </div>
+
+        <div className="rounded-xl bg-blue-50 dark:bg-blue-900/20 px-3.5 py-3">
+          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+            <QrCode className="size-4 text-blue-500" />
+            쉬운 참여
+          </div>
+          <p className="mt-1 text-sm text-text-subtitle">
+            링크/QR로 학생을 바로 초대할 수 있습니다.
+          </p>
+        </div>
+
+        <div className="rounded-xl bg-emerald-50 dark:bg-emerald-900/20 px-3.5 py-3">
+          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+            <RefreshCw className="size-4 text-emerald-500" />
+            재투표 지원
+          </div>
+          <p className="mt-1 text-sm text-text-subtitle">
+            종료 후 선택지를 골라 다시 투표를 만들 수 있습니다.
+          </p>
+        </div>
+
+        <div className="rounded-xl bg-violet-50 dark:bg-violet-900/20 px-3.5 py-3">
+          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+            <BarChart3 className="size-4 text-violet-500" />
+            결과 분석
+          </div>
+          <p className="mt-1 text-sm text-text-subtitle">
+            실시간 집계와 최종 결과를 바로 확인합니다.
+          </p>
+        </div>
+
+        <div className="rounded-xl bg-cyan-50 dark:bg-cyan-900/20 px-3.5 py-3">
+          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+            <Users2 className="size-4 text-cyan-500" />
+            실시간 동기화
+          </div>
+          <p className="mt-1 text-sm text-text-subtitle">
+            참여, 시작, 결과가 즉시 반영됩니다.
+          </p>
+        </div>
+
+        <div className="rounded-xl bg-amber-50 dark:bg-amber-900/20 px-3.5 py-3">
+          <div className="flex items-center gap-2 text-base font-semibold text-text-title">
+            <Timer className="size-4 text-amber-500" />
+            진행 제어
+          </div>
+          <p className="mt-1 text-sm text-text-subtitle">
+            교사가 시작/종료를 제어합니다.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border dark:border-gray-800 bg-white/90 dark:bg-gray-950 px-4 py-4 space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold text-text-title">
+            지금 바로 투표 시작하기
+          </h2>
+          <p className="text-sm text-text-subtitle">
+            투표 제목을 입력하고 만들기 버튼을 눌러 새 투표방을 생성하세요.
+          </p>
+        </div>
+        <Input
+          value={roomTitle}
+          onChange={(event) => setRoomTitle(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              handleCreateRoom();
+            }
           }}
+          placeholder="투표 제목을 입력하세요."
+          className="h-12 text-lg"
+        />
+        <Button
+          variant="primary"
+          onClick={handleCreateRoom}
+          disabled={!roomTitle.trim() || isPending}
+          className="h-12 text-base w-full"
         >
-          투표 목록 초기화
+          {isPending ? (
+            <LoaderCircle className="size-5 text-white animate-spin" />
+          ) : (
+            '만들기'
+          )}
         </Button>
       </div>
-
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {hasLoadingRoom
-          ? Array.from({ length: 3 }).map((_, index) => (
-              <Skeleton
-                // eslint-disable-next-line react/no-array-index-key
-                key={index}
-                className="w-full aspect-video rounded-md"
-              />
-            ))
-          : voteRooms.map((room) => (
-              <button
-                type="button"
-                key={room.roomId}
-                className="aspect-video rounded-md border dark:border-gray-700 p-4 text-left flex flex-col justify-between hover:bg-gray-50 dark:hover:bg-gray-900"
-                onClick={() => {
-                  setActiveRoomId(room.roomId);
-                  router.push(`/vote/teacher/${room.roomId}`);
-                }}
-              >
-                <div className="text-lg font-semibold text-text-title line-clamp-2">
-                  {room.title}
-                </div>
-                <div className="text-sm text-text-subtitle">
-                  <div>
-                    상태:{' '}
-                    {room.status === 'live'
-                      ? '진행 중'
-                      : room.status === 'ended'
-                        ? '종료됨'
-                        : '준비 중'}
-                  </div>
-                  <div className="line-clamp-1">
-                    질문: {room.currentRound?.question ?? '아직 없음'}
-                  </div>
-                </div>
-                <div className="text-primary flex items-center gap-1 text-sm">
-                  방 입장하기
-                  <ChevronRight className="size-4" />
-                </div>
-              </button>
-            ))}
-
-        <button
-          type="button"
-          className="aspect-video rounded-md border-2 border-dashed border-primary-300 text-primary flex items-center justify-center hover:bg-primary-50 dark:hover:bg-gray-900"
-          onClick={() => setIsCreateModalOpen(true)}
-        >
-          <Plus className="size-8" />
-        </button>
-      </div>
-
-      <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>투표방 만들기</DialogTitle>
-            <DialogDescription className="pt-4 space-y-4">
-              <Input
-                value={roomTitle}
-                onChange={(event) => setRoomTitle(event.target.value)}
-                placeholder="투표 제목을 입력해주세요."
-              />
-              <div className="flex justify-end">
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onClick={handleCreateRoom}
-                  disabled={!roomTitle.trim() || isPending}
-                >
-                  {isPending ? (
-                    <LoaderCircle className="size-4 text-white animate-spin" />
-                  ) : (
-                    '방 만들기'
-                  )}
-                </Button>
-              </div>
-            </DialogDescription>
-          </DialogHeader>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={hasPendingRestore} onOpenChange={setShowRestoreModal}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>진행 중인 투표가 있어요</DialogTitle>
-            <DialogDescription className="pt-4 text-sm text-text-subtitle">
-              이전에 진행하던 투표를 계속할지, 초기화하고 새로 시작할지
-              선택해주세요.
-            </DialogDescription>
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="gray-ghost"
-                size="sm"
-                onClick={() => {
-                  setActiveRoomId('');
-                  setShowRestoreModal(false);
-                }}
-              >
-                초기화하고 새로 만들기
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={() => {
-                  setShowRestoreModal(false);
-                  router.push(`/vote/teacher/${activeRoomId}`);
-                }}
-              >
-                계속하기
-              </Button>
-            </div>
-          </DialogHeader>
-        </DialogContent>
-      </Dialog>
-    </>
+      <ul className="list-disc pl-5 space-y-1 text-xs leading-relaxed text-text-subtitle">
+        <li>투표방 목록은 제공하지 않습니다.</li>
+        <li>생성한 투표방은 목록으로 재사용되지 않습니다.</li>
+        <li>다시 접속하려면 방 주소를 별도로 보관해주세요.</li>
+      </ul>
+    </div>
   );
 }

--- a/src/containers/vote/vote-room-id.ts
+++ b/src/containers/vote/vote-room-id.ts
@@ -1,0 +1,9 @@
+const UUID_PATTERN =
+  /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/;
+
+export const normalizeVoteRoomId = (rawRoomId: string) => {
+  const matchedUuid = rawRoomId.match(UUID_PATTERN);
+  return matchedUuid?.[0] ?? rawRoomId;
+};
+
+export const isUuid = (value: string) => UUID_PATTERN.test(value);

--- a/src/containers/vote/vote-student/vote-student-container.tsx
+++ b/src/containers/vote/vote-student/vote-student-container.tsx
@@ -12,6 +12,7 @@ import { Heading2 } from '@/components/heading';
 import { useJoinVoteRoomParticipant } from '@/hooks/apis/vote/use-join-vote-room-participant';
 import { useGetVoteStudentSnapshot } from '@/hooks/apis/vote/use-get-vote-snapshot';
 import { useSubmitVoteBallot } from '@/hooks/apis/vote/use-submit-vote-ballot';
+import { useVoteStudentRealtime } from '@/hooks/apis/vote/use-vote-realtime';
 
 type Props = {
   params: {
@@ -39,6 +40,7 @@ export default function VoteStudentContainer({ params }: Props) {
     roomId,
     participantToken,
   });
+  useVoteStudentRealtime(roomId, Boolean(roomId && participantToken), refetch);
 
   useEffect(() => {
     const cookieName = Cookies.get(getParticipantNameCookieKey(roomId)) ?? '';
@@ -62,12 +64,12 @@ export default function VoteStudentContainer({ params }: Props) {
   }, [roomId]);
 
   useEffect(() => {
-    if (!participantName || !participantToken) return;
+    if (!participantToken) return;
 
     joinParticipant({
       roomId,
       token: participantToken,
-      name: participantName,
+      name: participantName || '익명',
     });
   }, [joinParticipant, participantName, participantToken, roomId]);
 

--- a/src/containers/vote/vote-student/vote-student-container.tsx
+++ b/src/containers/vote/vote-student/vote-student-container.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import Cookies from 'js-cookie';
+import { useEffect, useMemo, useState } from 'react';
+import { LoaderCircle } from 'lucide-react';
+import { Button } from '@/components/button';
+import { Input } from '@/components/input';
+import { Checkbox } from '@/components/checkbox';
+import { Label } from '@/components/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/card';
+import { Heading2 } from '@/components/heading';
+import { useJoinVoteRoomParticipant } from '@/hooks/apis/vote/use-join-vote-room-participant';
+import { useGetVoteStudentSnapshot } from '@/hooks/apis/vote/use-get-vote-snapshot';
+import { useSubmitVoteBallot } from '@/hooks/apis/vote/use-submit-vote-ballot';
+
+type Props = {
+  params: {
+    roomId: string;
+  };
+};
+
+const getParticipantTokenStorageKey = (roomId: string) =>
+  `vote-participant-token-${roomId}`;
+const getParticipantNameCookieKey = (roomId: string) =>
+  `vote-student-name-${roomId}`;
+
+export default function VoteStudentContainer({ params }: Props) {
+  const { roomId } = params;
+  const [participantToken, setParticipantToken] = useState('');
+  const [nameInput, setNameInput] = useState('');
+  const [participantName, setParticipantName] = useState('');
+  const [selectedOptionIds, setSelectedOptionIds] = useState<string[]>([]);
+  const [errorMessage, setErrorMessage] = useState('');
+  const { mutate: joinParticipant } = useJoinVoteRoomParticipant();
+  const { mutate: submitVoteBallotMutation, isPending: isSubmitting } =
+    useSubmitVoteBallot();
+
+  const { data, isLoading, refetch } = useGetVoteStudentSnapshot({
+    roomId,
+    participantToken,
+  });
+
+  useEffect(() => {
+    const cookieName = Cookies.get(getParticipantNameCookieKey(roomId)) ?? '';
+    setParticipantName(cookieName);
+    setNameInput(cookieName);
+  }, [roomId]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const storageKey = getParticipantTokenStorageKey(roomId);
+    const existingToken = window.localStorage.getItem(storageKey);
+    if (existingToken) {
+      setParticipantToken(existingToken);
+      return;
+    }
+
+    const nextToken = crypto.randomUUID();
+    window.localStorage.setItem(storageKey, nextToken);
+    setParticipantToken(nextToken);
+  }, [roomId]);
+
+  useEffect(() => {
+    if (!participantName || !participantToken) return;
+
+    joinParticipant({
+      roomId,
+      token: participantToken,
+      name: participantName,
+    });
+  }, [joinParticipant, participantName, participantToken, roomId]);
+
+  const liveRound = data?.liveRound;
+  const maxSelections = liveRound?.maxSelections ?? 1;
+
+  const canSubmit = useMemo(() => {
+    if (!liveRound) return false;
+    return (
+      selectedOptionIds.length > 0 && selectedOptionIds.length <= maxSelections
+    );
+  }, [liveRound, maxSelections, selectedOptionIds.length]);
+
+  const handleSaveName = () => {
+    const trimmedName = nameInput.trim();
+    if (!trimmedName) {
+      setErrorMessage('이름을 입력해주세요.');
+      return;
+    }
+
+    Cookies.set(getParticipantNameCookieKey(roomId), trimmedName);
+    setParticipantName(trimmedName);
+    setErrorMessage('');
+  };
+
+  const handleSubmitVote = () => {
+    if (!liveRound) return;
+    if (!participantToken || !participantName) return;
+    if (!canSubmit) {
+      setErrorMessage(
+        `최소 1개, 최대 ${maxSelections}개의 선택지를 선택한 뒤 전송해주세요.`,
+      );
+      return;
+    }
+
+    submitVoteBallotMutation(
+      {
+        roomId,
+        roundId: liveRound.id,
+        optionIds: selectedOptionIds,
+        participantToken,
+        participantName,
+      },
+      {
+        onSuccess: () => {
+          setSelectedOptionIds([]);
+          setErrorMessage('');
+          refetch();
+        },
+        onError: (error) => {
+          setErrorMessage(error.message);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4 space-y-4">
+      <Heading2>티처캔 투표하기</Heading2>
+      <Card>
+        <CardHeader>
+          <CardTitle>방 정보</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1 text-sm text-text-subtitle">
+          <div>방 이름: {data?.roomTitle ?? '-'}</div>
+          {participantName && <div>내 이름: {participantName}</div>}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>입장 이름 설정</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Input
+            value={nameInput}
+            onChange={(event) => setNameInput(event.target.value)}
+            placeholder="이름을 입력하세요."
+          />
+          <Button variant="primary" size="sm" onClick={handleSaveName}>
+            이름 저장
+          </Button>
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <div className="w-full flex justify-center py-10">
+          <LoaderCircle className="size-5 animate-spin text-primary" />
+        </div>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>현재 투표</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!participantName ? (
+              <div className="text-sm text-text-subtitle">
+                투표에 참여하려면 먼저 이름을 저장해주세요.
+              </div>
+            ) : data?.alreadySubmitted ? (
+              <div className="text-sm text-text-subtitle">
+                투표 전송이 완료되었습니다. 선생님이 투표를 마칠 때까지
+                기다려주세요.
+              </div>
+            ) : !liveRound ? (
+              <div className="text-sm text-text-subtitle">
+                아직 시작된 투표가 없습니다. 잠시 후 다시 확인해주세요.
+              </div>
+            ) : (
+              <>
+                <div className="space-y-1">
+                  <div className="font-semibold text-text-title">
+                    {liveRound.question}
+                  </div>
+                  <div className="text-sm text-text-subtitle">
+                    최대 {maxSelections}개까지 선택할 수 있습니다.
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  {liveRound.options.map((option) => (
+                    <Label
+                      key={option.id}
+                      className="flex items-center gap-2 text-text-title"
+                    >
+                      <Checkbox
+                        checked={selectedOptionIds.includes(option.id)}
+                        onCheckedChange={(checked) => {
+                          setSelectedOptionIds((previous) => {
+                            if (checked) {
+                              if (previous.length >= maxSelections) {
+                                return previous;
+                              }
+                              return [...previous, option.id];
+                            }
+                            return previous.filter((id) => id !== option.id);
+                          });
+                        }}
+                      />
+                      {option.label}
+                    </Label>
+                  ))}
+                </div>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  isPending={isSubmitting}
+                  onClick={handleSubmitVote}
+                >
+                  전송하기
+                </Button>
+              </>
+            )}
+
+            {errorMessage && <p className="text-sm text-red">{errorMessage}</p>}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/containers/vote/vote-student/vote-student-container.tsx
+++ b/src/containers/vote/vote-student/vote-student-container.tsx
@@ -1,12 +1,8 @@
 'use client';
 
-import Cookies from 'js-cookie';
 import { useEffect, useMemo, useState } from 'react';
-import { LoaderCircle } from 'lucide-react';
+import { Check, LoaderCircle } from 'lucide-react';
 import { Button } from '@/components/button';
-import { Input } from '@/components/input';
-import { Checkbox } from '@/components/checkbox';
-import { Label } from '@/components/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/card';
 import { Heading2 } from '@/components/heading';
 import { useJoinVoteRoomParticipant } from '@/hooks/apis/vote/use-join-vote-room-participant';
@@ -22,15 +18,11 @@ type Props = {
 
 const getParticipantTokenStorageKey = (roomId: string) =>
   `vote-participant-token-${roomId}`;
-const getParticipantNameCookieKey = (roomId: string) =>
-  `vote-student-name-${roomId}`;
 
 export default function VoteStudentContainer({ params }: Props) {
   const { roomId } = params;
   const [participantToken, setParticipantToken] = useState('');
-  const [nameInput, setNameInput] = useState('');
-  const [participantName, setParticipantName] = useState('');
-  const [selectedOptionIds, setSelectedOptionIds] = useState<string[]>([]);
+  const [selectedOptionKeys, setSelectedOptionKeys] = useState<string[]>([]);
   const [errorMessage, setErrorMessage] = useState('');
   const { mutate: joinParticipant } = useJoinVoteRoomParticipant();
   const { mutate: submitVoteBallotMutation, isPending: isSubmitting } =
@@ -41,12 +33,6 @@ export default function VoteStudentContainer({ params }: Props) {
     participantToken,
   });
   useVoteStudentRealtime(roomId, Boolean(roomId && participantToken), refetch);
-
-  useEffect(() => {
-    const cookieName = Cookies.get(getParticipantNameCookieKey(roomId)) ?? '';
-    setParticipantName(cookieName);
-    setNameInput(cookieName);
-  }, [roomId]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -69,12 +55,46 @@ export default function VoteStudentContainer({ params }: Props) {
     joinParticipant({
       roomId,
       token: participantToken,
-      name: participantName || '익명',
+      // 학생 이름은 DB에 남기지 않고 익명으로만 저장합니다.
+      name: '익명',
     });
-  }, [joinParticipant, participantName, participantToken, roomId]);
+  }, [joinParticipant, participantToken, roomId]);
 
   const liveRound = data?.liveRound;
+  const options = useMemo(() => liveRound?.options ?? [], [liveRound?.options]);
   const maxSelections = liveRound?.maxSelections ?? 1;
+  const optionViewModels = useMemo(() => {
+    const idCount = new Map<string, number>();
+
+    return options.map((option) => {
+      const nextCount = (idCount.get(option.id) ?? 0) + 1;
+      idCount.set(option.id, nextCount);
+
+      return {
+        key: `${option.id}-${nextCount}`,
+        optionId: option.id,
+        label: option.label,
+      };
+    });
+  }, [options]);
+  const optionIdByKey = useMemo(
+    () =>
+      new Map(
+        optionViewModels.map((viewModel) => [
+          viewModel.key,
+          viewModel.optionId,
+        ]),
+      ),
+    [optionViewModels],
+  );
+
+  const selectedOptionIds = useMemo(
+    () =>
+      selectedOptionKeys
+        .map((key) => optionIdByKey.get(key))
+        .filter((value): value is string => Boolean(value)),
+    [optionIdByKey, selectedOptionKeys],
+  );
 
   const canSubmit = useMemo(() => {
     if (!liveRound) return false;
@@ -83,21 +103,14 @@ export default function VoteStudentContainer({ params }: Props) {
     );
   }, [liveRound, maxSelections, selectedOptionIds.length]);
 
-  const handleSaveName = () => {
-    const trimmedName = nameInput.trim();
-    if (!trimmedName) {
-      setErrorMessage('이름을 입력해주세요.');
-      return;
-    }
-
-    Cookies.set(getParticipantNameCookieKey(roomId), trimmedName);
-    setParticipantName(trimmedName);
+  useEffect(() => {
+    setSelectedOptionKeys([]);
     setErrorMessage('');
-  };
+  }, [liveRound?.id]);
 
   const handleSubmitVote = () => {
     if (!liveRound) return;
-    if (!participantToken || !participantName) return;
+    if (!participantToken) return;
     if (!canSubmit) {
       setErrorMessage(
         `최소 1개, 최대 ${maxSelections}개의 선택지를 선택한 뒤 전송해주세요.`,
@@ -111,11 +124,11 @@ export default function VoteStudentContainer({ params }: Props) {
         roundId: liveRound.id,
         optionIds: selectedOptionIds,
         participantToken,
-        participantName,
+        participantName: '익명',
       },
       {
         onSuccess: () => {
-          setSelectedOptionIds([]);
+          setSelectedOptionKeys([]);
           setErrorMessage('');
           refetch();
         },
@@ -126,105 +139,123 @@ export default function VoteStudentContainer({ params }: Props) {
     );
   };
 
-  return (
-    <div className="max-w-2xl mx-auto py-8 px-4 space-y-4">
-      <Heading2>티처캔 투표하기</Heading2>
-      <Card>
-        <CardHeader>
-          <CardTitle>방 정보</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-1 text-sm text-text-subtitle">
-          <div>방 이름: {data?.roomTitle ?? '-'}</div>
-          {participantName && <div>내 이름: {participantName}</div>}
-        </CardContent>
-      </Card>
+  const handleToggleOption = (targetKey: string) => {
+    const alreadySelected = selectedOptionKeys.includes(targetKey);
+    if (alreadySelected) {
+      setSelectedOptionKeys((previous) =>
+        previous.filter((key) => key !== targetKey),
+      );
+      setErrorMessage('');
+      return;
+    }
 
-      <Card>
-        <CardHeader>
-          <CardTitle>입장 이름 설정</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <Input
-            value={nameInput}
-            onChange={(event) => setNameInput(event.target.value)}
-            placeholder="이름을 입력하세요."
-          />
-          <Button variant="primary" size="sm" onClick={handleSaveName}>
-            이름 저장
-          </Button>
-        </CardContent>
-      </Card>
+    if (maxSelections <= 1) {
+      setSelectedOptionKeys([targetKey]);
+      setErrorMessage('');
+      return;
+    }
+
+    if (selectedOptionKeys.length >= maxSelections) {
+      setErrorMessage(
+        `최대 ${maxSelections}개까지 고를 수 있어요. 먼저 고른 선택지를 다시 눌러 지운 뒤, 다시 골라주세요.`,
+      );
+      return;
+    }
+
+    setSelectedOptionKeys((previous) => [...previous, targetKey]);
+    setErrorMessage('');
+  };
+
+  let voteContent = (
+    <>
+      <div className="space-y-1">
+        <div className="font-semibold text-text-title">
+          {liveRound?.question}
+        </div>
+        <div className="text-sm text-text-subtitle">
+          최대 {maxSelections}개까지 선택할 수 있습니다.
+        </div>
+      </div>
+      <div className="space-y-3">
+        {optionViewModels.map((viewModel) => {
+          const isSelected = selectedOptionKeys.includes(viewModel.key);
+
+          return (
+            <button
+              key={viewModel.key}
+              type="button"
+              onClick={() => handleToggleOption(viewModel.key)}
+              aria-pressed={isSelected}
+              disabled={isSubmitting}
+              className={`w-full text-left rounded-2xl border px-4 py-4 min-h-16 transition ${
+                isSelected
+                  ? 'border-primary bg-primary-50/70 shadow-sm'
+                  : 'border-gray-200 bg-white hover:border-gray-300'
+              }`}
+            >
+              <div className="flex items-center gap-3 text-text-title">
+                <div
+                  className={`mt-0.5 flex size-5 items-center justify-center rounded-md border ${
+                    isSelected
+                      ? 'border-primary bg-primary text-white'
+                      : 'border-gray-300 bg-white'
+                  }`}
+                >
+                  {isSelected ? <Check className="size-3.5" /> : null}
+                </div>
+                <span className="text-base leading-6">{viewModel.label}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      {errorMessage && <p className="text-sm text-red">{errorMessage}</p>}
+      <Button
+        variant="primary"
+        size="sm"
+        isPending={isSubmitting}
+        onClick={handleSubmitVote}
+        className="w-full h-12 text-base"
+      >
+        전송하기
+      </Button>
+    </>
+  );
+
+  if (data?.alreadySubmitted) {
+    voteContent = (
+      <div className="text-sm text-text-subtitle">
+        투표 전송이 완료되었습니다. 선생님이 투표를 마칠 때까지 기다려주세요.
+      </div>
+    );
+  } else if (!liveRound) {
+    voteContent = (
+      <div className="text-sm text-text-subtitle">
+        아직 시작된 투표가 없습니다. 잠시 후 다시 확인해주세요.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-xl mx-auto py-8 px-4 space-y-4 min-h-screen">
+      <Heading2>티처캔 투표하기</Heading2>
+      <div className="rounded-xl border border-gray-200 bg-white px-4 py-3 space-y-1.5">
+        <div className="text-sm text-text-subtitle">방 이름</div>
+        <div className="font-semibold text-text-title">
+          {data?.roomTitle ?? '-'}
+        </div>
+      </div>
 
       {isLoading ? (
         <div className="w-full flex justify-center py-10">
           <LoaderCircle className="size-5 animate-spin text-primary" />
         </div>
       ) : (
-        <Card>
+        <Card className="bg-white border-gray-200">
           <CardHeader>
             <CardTitle>현재 투표</CardTitle>
           </CardHeader>
-          <CardContent className="space-y-4">
-            {!participantName ? (
-              <div className="text-sm text-text-subtitle">
-                투표에 참여하려면 먼저 이름을 저장해주세요.
-              </div>
-            ) : data?.alreadySubmitted ? (
-              <div className="text-sm text-text-subtitle">
-                투표 전송이 완료되었습니다. 선생님이 투표를 마칠 때까지
-                기다려주세요.
-              </div>
-            ) : !liveRound ? (
-              <div className="text-sm text-text-subtitle">
-                아직 시작된 투표가 없습니다. 잠시 후 다시 확인해주세요.
-              </div>
-            ) : (
-              <>
-                <div className="space-y-1">
-                  <div className="font-semibold text-text-title">
-                    {liveRound.question}
-                  </div>
-                  <div className="text-sm text-text-subtitle">
-                    최대 {maxSelections}개까지 선택할 수 있습니다.
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  {liveRound.options.map((option) => (
-                    <Label
-                      key={option.id}
-                      className="flex items-center gap-2 text-text-title"
-                    >
-                      <Checkbox
-                        checked={selectedOptionIds.includes(option.id)}
-                        onCheckedChange={(checked) => {
-                          setSelectedOptionIds((previous) => {
-                            if (checked) {
-                              if (previous.length >= maxSelections) {
-                                return previous;
-                              }
-                              return [...previous, option.id];
-                            }
-                            return previous.filter((id) => id !== option.id);
-                          });
-                        }}
-                      />
-                      {option.label}
-                    </Label>
-                  ))}
-                </div>
-                <Button
-                  variant="primary"
-                  size="sm"
-                  isPending={isSubmitting}
-                  onClick={handleSubmitVote}
-                >
-                  전송하기
-                </Button>
-              </>
-            )}
-
-            {errorMessage && <p className="text-sm text-red">{errorMessage}</p>}
-          </CardContent>
+          <CardContent className="space-y-4">{voteContent}</CardContent>
         </Card>
       )}
     </div>

--- a/src/containers/vote/vote-teacher/vote-teacher-container.tsx
+++ b/src/containers/vote/vote-teacher/vote-teacher-container.tsx
@@ -1,9 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { QRCodeCanvas } from 'qrcode.react';
-import { LoaderCircle, Plus, RefreshCw, Trash2, Users } from 'lucide-react';
+import {
+  Copy,
+  ExternalLink,
+  LoaderCircle,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Users,
+  ZoomIn,
+} from 'lucide-react';
 import { Button } from '@/components/button';
 import { Heading1, Heading3 } from '@/components/heading';
 import { Input } from '@/components/input';
@@ -18,6 +27,13 @@ import { useCreateVoteRound } from '@/hooks/apis/vote/use-create-vote-round';
 import { useStartVoteRound } from '@/hooks/apis/vote/use-start-vote-round';
 import { useEndVoteRound } from '@/hooks/apis/vote/use-end-vote-round';
 import { useFinishVoteRoom } from '@/hooks/apis/vote/use-finish-vote-room';
+import { useToast } from '@/hooks/use-toast';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/dialog';
 import { VoteTeacherSnapshot } from '@/apis/vote/vote';
 import { MAX_VOTE_OPTIONS } from '../vote-constants';
 
@@ -28,16 +44,27 @@ type Props = {
 };
 
 const DEFAULT_OPTIONS = ['', ''];
+type RevoteOptionItem = {
+  id: string;
+  label: string;
+  isCustom: boolean;
+};
 
 export default function VoteTeacherContainer({ params }: Props) {
   const { roomId } = params;
   const router = useRouter();
+  const { toast } = useToast();
+  const qrContainerRef = useRef<HTMLDivElement | null>(null);
   const { data, refetch } = useGetVoteTeacherSnapshot({ roomId });
   const [snapshot, setSnapshot] = useState<VoteTeacherSnapshot | null>(null);
   const [question, setQuestion] = useState('');
   const [options, setOptions] = useState<string[]>(DEFAULT_OPTIONS);
   const [maxSelections, setMaxSelections] = useState(1);
   const [revoteOptionIds, setRevoteOptionIds] = useState<string[]>([]);
+  const [revoteOptions, setRevoteOptions] = useState<RevoteOptionItem[]>([]);
+  const [revoteOptionDraft, setRevoteOptionDraft] = useState('');
+  const [revoteQuestion, setRevoteQuestion] = useState('');
+  const [revoteMaxSelections, setRevoteMaxSelections] = useState(1);
   const [origin, setOrigin] = useState('');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [isCreatingRevote, setIsCreatingRevote] = useState(false);
@@ -70,6 +97,8 @@ export default function VoteTeacherContainer({ params }: Props) {
   }, []);
 
   const currentRound = snapshot?.currentRound ?? null;
+  const isConnectionHealthy = connectionStatus === 'connected';
+  const inviteUrl = `${origin}/vote/student/${roomId}`;
   const latestEndedRound = useMemo(
     () => snapshot?.rounds.find((round) => round.status === 'ended') ?? null,
     [snapshot],
@@ -149,6 +178,10 @@ export default function VoteTeacherContainer({ params }: Props) {
           setQuestion('');
           setMaxSelections(1);
           setRevoteOptionIds([]);
+          setRevoteOptions([]);
+          setRevoteOptionDraft('');
+          setRevoteQuestion('');
+          setRevoteMaxSelections(1);
           setIsCreatingRevote(false);
           refetch();
         },
@@ -192,18 +225,251 @@ export default function VoteTeacherContainer({ params }: Props) {
     );
   };
 
+  const initializeRevoteForm = () => {
+    if (!currentRound) return;
+    const initialRevoteOptions = currentRound.options.map((option) => ({
+      id: option.id,
+      label: option.label,
+      isCustom: false,
+    }));
+    setRevoteOptions(initialRevoteOptions);
+    setRevoteOptionIds([]);
+    setRevoteOptionDraft('');
+    setRevoteQuestion(currentRound.question);
+    setRevoteMaxSelections(Math.max(1, currentRound.maxSelections));
+  };
+
+  const addRevoteOption = () => {
+    const label = revoteOptionDraft.trim();
+    if (!label) return;
+
+    const customOptionId = `custom-${Date.now()}-${Math.floor(Math.random() * 100000)}`;
+    const customOption: RevoteOptionItem = {
+      id: customOptionId,
+      label,
+      isCustom: true,
+    };
+
+    setRevoteOptions((previous) => {
+      return [...previous, customOption];
+    });
+    setRevoteOptionIds((previous) => {
+      if (previous.length >= MAX_VOTE_OPTIONS) {
+        toast({
+          title: `선택지는 최대 ${MAX_VOTE_OPTIONS}개까지만 선택할 수 있어요.`,
+          variant: 'error',
+        });
+        return previous;
+      }
+      return [...previous, customOptionId];
+    });
+    setRevoteOptionDraft('');
+  };
+
+  const removeRevoteOption = (optionId: string) => {
+    setRevoteOptions((previous) =>
+      previous.filter((option) => option.id !== optionId),
+    );
+    setRevoteOptionIds((previous) => previous.filter((id) => id !== optionId));
+  };
+
+  const toggleRevoteOption = (optionId: string) => {
+    setRevoteOptionIds((previous) => {
+      if (previous.includes(optionId)) {
+        return previous.filter((id) => id !== optionId);
+      }
+      if (previous.length >= MAX_VOTE_OPTIONS) {
+        toast({
+          title: `선택지는 최대 ${MAX_VOTE_OPTIONS}개까지만 선택할 수 있어요.`,
+          variant: 'error',
+        });
+        return previous;
+      }
+      return [...previous, optionId];
+    });
+  };
+
   const buildRevote = () => {
     if (!currentRound) return;
+    const trimmedRevoteQuestion = revoteQuestion.trim();
+
+    if (!trimmedRevoteQuestion) {
+      setErrorMessage('재투표 질문을 입력해주세요.');
+      return;
+    }
+
     if (revoteOptionIds.length < 2) {
       setErrorMessage('재투표는 최소 2개 선택지로 설정해주세요.');
       return;
     }
 
-    const revoteOptions = currentRound.options
-      .filter((option) => revoteOptionIds.includes(option.id))
-      .map((option) => option.label);
+    if (revoteMaxSelections > revoteOptionIds.length) {
+      setErrorMessage('최대 선택 개수는 선택지 개수를 넘을 수 없습니다.');
+      return;
+    }
 
-    createRound(revoteOptions);
+    const selectedRevoteOptions = revoteOptions
+      .filter((option) => revoteOptionIds.includes(option.id))
+      .map((option) => option.label.trim())
+      .filter(Boolean);
+
+    setErrorMessage('');
+    createVoteRoundMutation(
+      {
+        roomId,
+        question: trimmedRevoteQuestion,
+        maxSelections: revoteMaxSelections,
+        options: selectedRevoteOptions,
+      },
+      {
+        onSuccess: () => {
+          setOptions(DEFAULT_OPTIONS);
+          setQuestion('');
+          setMaxSelections(1);
+          setRevoteOptionIds([]);
+          setRevoteOptions([]);
+          setRevoteOptionDraft('');
+          setRevoteQuestion('');
+          setRevoteMaxSelections(1);
+          setIsCreatingRevote(false);
+          refetch();
+        },
+        onError: (error) => {
+          setErrorMessage(error.message);
+        },
+      },
+    );
+  };
+
+  const copyInviteUrl = async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(inviteUrl);
+      } else {
+        const textArea = document.createElement('textarea');
+        textArea.value = inviteUrl;
+        textArea.style.position = 'fixed';
+        textArea.style.opacity = '0';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+      }
+      toast({
+        title: 'URL이 복사되었습니다.',
+        variant: 'success',
+      });
+    } catch (error) {
+      console.error('초대 링크 복사 실패:', error);
+      toast({
+        title: '링크 복사에 실패했어요.',
+        variant: 'error',
+      });
+    }
+  };
+
+  const openQrInPopupWindow = () => {
+    const canvasElement = qrContainerRef.current?.querySelector('canvas');
+    if (!canvasElement) {
+      toast({
+        title: 'QR 코드를 불러오는 중이에요. 잠시 후 다시 시도해주세요.',
+        variant: 'error',
+      });
+      return;
+    }
+
+    const exportCanvas = document.createElement('canvas');
+    const exportSize = 1200;
+    exportCanvas.width = exportSize;
+    exportCanvas.height = exportSize;
+    const exportContext = exportCanvas.getContext('2d');
+    if (exportContext) {
+      exportContext.imageSmoothingEnabled = false;
+      exportContext.drawImage(canvasElement, 0, 0, exportSize, exportSize);
+    }
+
+    const qrImageDataUrl = exportCanvas.toDataURL('image/png');
+    const popupWidth = window.screen.availWidth;
+    const popupHeight = window.screen.availHeight;
+    const popupWindow = window.open(
+      '',
+      'vote-qr-popup',
+      `popup=yes,width=${popupWidth},height=${popupHeight},left=0,top=0`,
+    );
+
+    if (!popupWindow) {
+      toast({
+        title: '팝업이 차단되었어요. 브라우저 설정을 확인해주세요.',
+        variant: 'error',
+      });
+      return;
+    }
+
+    popupWindow.document.write(`
+      <!DOCTYPE html>
+      <html lang="ko">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>투표 초대 QR</title>
+        <style>
+          html, body {
+            width: 100%;
+            height: 100%;
+          }
+          body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: #f8fafc;
+            color: #0f172a;
+          }
+          main {
+            width: 100%;
+            height: 100%;
+            display: grid;
+            grid-template-rows: 1fr auto;
+          }
+          .qr-wrap {
+            padding: 16px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+          }
+          img {
+            width: min(100vw, calc(100vh - 64px));
+            height: min(100vw, calc(100vh - 64px));
+            object-fit: contain;
+            border-radius: 16px;
+            background: #fff;
+            padding: 12px;
+            box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+            image-rendering: crisp-edges;
+            image-rendering: pixelated;
+          }
+          p {
+            margin: 0;
+            padding: 10px 16px 14px;
+            font-size: 13px;
+            color: #475569;
+            text-align: center;
+            word-break: break-all;
+            background: rgba(248, 250, 252, 0.95);
+          }
+        </style>
+      </head>
+      <body>
+        <main>
+          <div class="qr-wrap">
+            <img src="${qrImageDataUrl}" alt="투표 초대 QR 코드" />
+          </div>
+          <p>${inviteUrl}</p>
+        </main>
+      </body>
+      </html>
+    `);
+    popupWindow.document.close();
   };
 
   if (!snapshot) {
@@ -214,313 +480,540 @@ export default function VoteTeacherContainer({ params }: Props) {
     );
   }
 
+  const roomStatusTextMap = {
+    live: '투표 진행 중',
+    ended: '투표 종료',
+    draft: '투표 준비',
+  } as const;
+  const roomStatusText = roomStatusTextMap[snapshot.room.status];
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between gap-3">
         <Heading1 className="mb-0">{snapshot.room.title}</Heading1>
         <div className="flex items-center gap-2">
-          <Badge variant="primary-outline">
-            연결 상태:{' '}
-            {connectionStatus === 'connected'
-              ? '정상'
-              : connectionStatus === 'reconnecting'
-                ? '재연결 중'
-                : '끊김'}
-          </Badge>
-          {connectionStatus !== 'connected' && (
-            <Button variant="gray-outline" size="sm" onClick={reconnect}>
-              <RefreshCw className="size-4 mr-1" />
-              다시 연결
-            </Button>
+          {isConnectionHealthy ? (
+            <Badge variant="primary-outline">연결 정상</Badge>
+          ) : (
+            <RefreshCw className="size-4" onClick={reconnect} />
           )}
         </div>
       </div>
 
-      <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
-        <Card className="xl:col-span-2">
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              <span>진행 상태</span>
-              <Badge>
-                {snapshot.room.status === 'live'
-                  ? '투표 진행 중'
-                  : snapshot.room.status === 'ended'
-                    ? '투표 종료'
-                    : '투표 준비'}
-              </Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center gap-2 text-sm text-text-subtitle">
-              <Users className="size-4" />
-              입장한 학생 수: {snapshot.joinedStudentCount}명
-            </div>
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] gap-4 items-start">
+        <div className="space-y-4 min-w-0">
+          <Card className="border-primary-100/70 dark:border-gray-800 shadow-sm">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                <span>진행 상태</span>
+                <Badge>{roomStatusText}</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-xl bg-gray-50 dark:bg-gray-900 px-3 py-2.5 flex items-center gap-2 text-sm text-text-subtitle">
+                <Users className="size-4 text-primary" />
+                입장 학생{' '}
+                <span className="font-semibold text-text-title">
+                  {snapshot.joinedStudentCount}명
+                </span>
+              </div>
 
-            {currentRound ? (
-              <>
-                <div className="space-y-1">
-                  <Heading3 className="text-base">
-                    {currentRound.question}
-                  </Heading3>
-                  <div className="text-sm text-text-subtitle">
-                    최대 선택 가능 개수: {currentRound.maxSelections}개
+              {currentRound ? (
+                <>
+                  <div className="rounded-xl border border-primary-100 dark:border-gray-800 p-4 bg-white dark:bg-gray-950">
+                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                      <Heading3 className="text-base leading-relaxed tracking-tight">
+                        {currentRound.question}
+                      </Heading3>
+                      <div className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold bg-primary-50 text-primary-700 dark:bg-primary-900/20 dark:text-primary-200 whitespace-nowrap">
+                        최대 선택 {currentRound.maxSelections}개
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    {currentRound.options.map((option) => {
+                      const totalVotes = Math.max(currentRound.totalVotes, 1);
+                      const ratio = Math.round(
+                        (option.voteCount / totalVotes) * 100,
+                      );
+                      return (
+                        <div
+                          key={option.id}
+                          className="space-y-2 rounded-lg border border-gray-200 dark:border-gray-800 px-3 py-4 bg-white dark:bg-gray-950"
+                        >
+                          <div className="flex justify-between text-sm items-center gap-2">
+                            <span className="font-medium leading-5">
+                              {option.label}
+                            </span>
+                            <span className="text-text-subtitle whitespace-nowrap text-xs">
+                              {option.voteCount}표 · {ratio}%
+                            </span>
+                          </div>
+                          <div className="w-full h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                            <div
+                              className="h-full bg-primary transition-all duration-300"
+                              style={{ width: `${ratio}%` }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {currentRound.status === 'ready' && (
+                    <Button
+                      variant="primary"
+                      onClick={handleStartRound}
+                      isPending={isStarting}
+                      className="w-full h-11"
+                    >
+                      투표 시작하기
+                    </Button>
+                  )}
+
+                  {currentRound.status === 'live' && (
+                    <Button
+                      variant="primary-outline"
+                      onClick={handleEndRound}
+                      isPending={isEnding}
+                      className="w-full h-11"
+                    >
+                      투표 종료하기
+                    </Button>
+                  )}
+
+                  {currentRound.status === 'ended' &&
+                    snapshot.room.status !== 'ended' && (
+                      <div>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                          <Button
+                            variant="gray"
+                            onClick={() => {
+                              setIsCreatingRevote((previous) => {
+                                const next = !previous;
+                                if (next) {
+                                  initializeRevoteForm();
+                                } else {
+                                  setRevoteOptionIds([]);
+                                  setRevoteOptions([]);
+                                  setRevoteOptionDraft('');
+                                  setRevoteQuestion('');
+                                  setRevoteMaxSelections(1);
+                                }
+                                return next;
+                              });
+                              setErrorMessage('');
+                            }}
+                            className="w-full h-11"
+                          >
+                            재투표 만들기
+                          </Button>
+                          <Button
+                            variant="gray"
+                            onClick={handleFinishRoom}
+                            isPending={isFinishing}
+                            className="w-full h-11"
+                          >
+                            마무리하기
+                          </Button>
+                        </div>
+
+                        {isCreatingRevote && (
+                          <div className="pt-3 space-y-3">
+                            <div className="text-sm text-text-subtitle">
+                              재투표 질문과 최대 선택 개수를 설정하고, 포함할
+                              선택지를 고를 수 있습니다.
+                            </div>
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                              <div className="space-y-2 md:col-span-2">
+                                <Label className="text-sm font-semibold text-text-title">
+                                  재투표 질문
+                                </Label>
+                                <Textarea
+                                  value={revoteQuestion}
+                                  onChange={(event) =>
+                                    setRevoteQuestion(event.target.value)
+                                  }
+                                  placeholder="재투표 질문을 입력하세요."
+                                  className="min-h-[88px]"
+                                />
+                              </div>
+                              <div className="space-y-2">
+                                <Label
+                                  htmlFor="revote-max-selections"
+                                  className="text-sm font-semibold text-text-title"
+                                >
+                                  최대 선택 개수
+                                </Label>
+                                <Input
+                                  id="revote-max-selections"
+                                  type="number"
+                                  min={1}
+                                  max={Math.max(1, revoteOptionIds.length)}
+                                  value={revoteMaxSelections}
+                                  onChange={(event) => {
+                                    const value = Number(event.target.value);
+                                    if (!Number.isNaN(value)) {
+                                      setRevoteMaxSelections(
+                                        Math.max(1, value),
+                                      );
+                                    }
+                                  }}
+                                />
+                              </div>
+                            </div>
+
+                            <div className="space-y-2">
+                              <div className="flex items-center justify-between">
+                                <Label className="text-sm font-semibold text-text-title">
+                                  선택지
+                                </Label>
+                                <span className="text-xs text-text-subtitle">
+                                  선택됨 {revoteOptionIds.length}/
+                                  {MAX_VOTE_OPTIONS}
+                                </span>
+                              </div>
+
+                              <div className="grid grid-cols-1 gap-3">
+                                {revoteOptions.map((option, index) => (
+                                  <div
+                                    key={option.id}
+                                    role="button"
+                                    tabIndex={0}
+                                    onClick={() =>
+                                      toggleRevoteOption(option.id)
+                                    }
+                                    onKeyDown={(event) => {
+                                      if (
+                                        event.key === 'Enter' ||
+                                        event.key === ' '
+                                      ) {
+                                        event.preventDefault();
+                                        toggleRevoteOption(option.id);
+                                      }
+                                    }}
+                                    className="flex min-h-12 items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-2 py-2 cursor-pointer"
+                                  >
+                                    <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary text-xs font-semibold px-1">
+                                      {index + 1}
+                                    </span>
+                                    <div className="flex items-center gap-2 flex-1 min-w-0">
+                                      <Checkbox
+                                        checked={revoteOptionIds.includes(
+                                          option.id,
+                                        )}
+                                        onCheckedChange={() =>
+                                          toggleRevoteOption(option.id)
+                                        }
+                                        className="pointer-events-none"
+                                      />
+                                      <span className="truncate">
+                                        {option.label}
+                                      </span>
+                                    </div>
+                                    {option.isCustom && (
+                                      <Button
+                                        type="button"
+                                        variant="gray-outline"
+                                        size="sm"
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          removeRevoteOption(option.id);
+                                        }}
+                                        className="h-8 w-8 min-w-0 p-0"
+                                        aria-label="추가한 선택지 삭제"
+                                      >
+                                        <Trash2 className="size-4" />
+                                      </Button>
+                                    )}
+                                  </div>
+                                ))}
+                              </div>
+
+                              <div className="flex min-h-10 items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-2 py-2">
+                                <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary text-xs font-semibold px-1">
+                                  <Plus className="size-4" />
+                                </span>
+                                <Input
+                                  value={revoteOptionDraft}
+                                  onChange={(event) =>
+                                    setRevoteOptionDraft(event.target.value)
+                                  }
+                                  placeholder="재투표 선택지 추가"
+                                  onKeyDown={(event) => {
+                                    if (event.key === 'Enter') {
+                                      event.preventDefault();
+                                      addRevoteOption();
+                                    }
+                                  }}
+                                  className="border-0 bg-transparent shadow-none focus-visible:ring-0"
+                                />
+                                <Button
+                                  variant="gray-outline"
+                                  size="sm"
+                                  onClick={addRevoteOption}
+                                  disabled={!revoteOptionDraft.trim()}
+                                  className="h-8 px-3"
+                                >
+                                  추가
+                                </Button>
+                              </div>
+                            </div>
+
+                            <Button
+                              variant="primary"
+                              size="sm"
+                              isPending={isRoundCreating}
+                              onClick={buildRevote}
+                              className="w-full h-11"
+                            >
+                              재투표 라운드 생성
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                </>
+              ) : (
+                <div className="text-sm text-text-subtitle rounded-xl border border-dashed dark:border-gray-700 px-4 py-5">
+                  아직 생성된 투표 라운드가 없습니다.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {!currentRound && (
+            <Card className="border-primary-100/70 dark:border-gray-800 shadow-sm">
+              <CardHeader>
+                <CardTitle>투표 만들기</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+                  <div className="space-y-2 md:col-span-3">
+                    <Label className="text-sm font-semibold text-text-title">
+                      질문
+                    </Label>
+                    <Textarea
+                      placeholder="질문을 입력하세요."
+                      value={question}
+                      onChange={(event) => setQuestion(event.target.value)}
+                      className="min-h-[92px] border-gray-200 dark:border-gray-700"
+                    />
+                  </div>
+
+                  <div className="rounded-lg px-3 py-3 flex flex-col gap-2">
+                    <Label htmlFor="max-selections">최대 선택 개수</Label>
+                    <Input
+                      id="max-selections"
+                      type="number"
+                      min={1}
+                      max={Math.max(
+                        1,
+                        options.filter((value) => value.trim()).length,
+                      )}
+                      value={maxSelections}
+                      onChange={(event) => {
+                        const value = Number(event.target.value);
+                        if (!Number.isNaN(value)) {
+                          setMaxSelections(Math.max(1, value));
+                        }
+                      }}
+                      className="bg-white dark:bg-gray-950"
+                    />
+                    <p className="text-xs text-text-subtitle">
+                      유효한 선택지 수 기준으로 자동 제한됩니다.
+                    </p>
                   </div>
                 </div>
 
-                <div className="space-y-3">
-                  {currentRound.options.map((option) => {
-                    const totalVotes = Math.max(currentRound.totalVotes, 1);
-                    const ratio = Math.round(
-                      (option.voteCount / totalVotes) * 100,
-                    );
-                    return (
-                      <div key={option.id} className="space-y-1">
-                        <div className="flex justify-between text-sm">
-                          <span>{option.label}</span>
-                          <span>{option.voteCount}표</span>
-                        </div>
-                        <div className="w-full h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
-                          <div
-                            className="h-full bg-primary transition-all"
-                            style={{ width: `${ratio}%` }}
-                          />
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-
-                {currentRound.status === 'ready' && (
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    onClick={handleStartRound}
-                    isPending={isStarting}
-                  >
-                    투표 시작하기
-                  </Button>
-                )}
-
-                {currentRound.status === 'live' && (
-                  <Button
-                    variant="red"
-                    size="sm"
-                    onClick={handleEndRound}
-                    isPending={isEnding}
-                  >
-                    투표 종료하기
-                  </Button>
-                )}
-
-                {currentRound.status === 'ended' &&
-                  snapshot.room.status !== 'ended' && (
-                    <div className="space-y-3">
-                      <div className="flex flex-wrap gap-2">
-                        <Button
-                          variant="gray-outline"
-                          size="sm"
-                          onClick={() => {
-                            setIsCreatingRevote((previous) => !previous);
-                            setErrorMessage('');
-                          }}
-                        >
-                          재투표 만들기
-                        </Button>
-                        <Button
-                          variant="primary"
-                          size="sm"
-                          onClick={handleFinishRoom}
-                          isPending={isFinishing}
-                        >
-                          마무리하기
-                        </Button>
-                      </div>
-
-                      {isCreatingRevote && (
-                        <div className="rounded-md border dark:border-gray-700 p-3 space-y-3">
-                          <div className="text-sm text-text-subtitle">
-                            재투표에 포함할 선택지를 고르고 질문을 수정할 수
-                            있습니다.
-                          </div>
-                          <Textarea
-                            value={question}
-                            onChange={(event) =>
-                              setQuestion(event.target.value)
-                            }
-                            placeholder="재투표 질문"
-                          />
-                          <div className="space-y-2">
-                            {currentRound.options.map((option) => (
-                              <Label
-                                key={option.id}
-                                className="flex items-center gap-2 text-sm"
-                              >
-                                <Checkbox
-                                  checked={revoteOptionIds.includes(option.id)}
-                                  onCheckedChange={(checked) => {
-                                    setRevoteOptionIds((previous) => {
-                                      if (checked) {
-                                        return [...previous, option.id];
-                                      }
-                                      return previous.filter(
-                                        (id) => id !== option.id,
-                                      );
-                                    });
-                                  }}
-                                />
-                                {option.label}
-                              </Label>
-                            ))}
-                          </div>
-                          <Button
-                            variant="primary"
-                            size="sm"
-                            isPending={isRoundCreating}
-                            onClick={buildRevote}
-                          >
-                            재투표 라운드 생성
-                          </Button>
-                        </div>
-                      )}
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-semibold text-text-title">
+                      선택지
+                    </Label>
+                    <span className="text-xs text-text-subtitle">
+                      {options.length}/{MAX_VOTE_OPTIONS}
+                    </span>
+                  </div>
+                  {options.map((option, index) => (
+                    <div
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={index}
+                      className="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-2 py-2"
+                    >
+                      <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary text-xs font-semibold px-1">
+                        {index + 1}
+                      </span>
+                      <Input
+                        value={option}
+                        onChange={(event) =>
+                          updateOptionValue(index, event.target.value)
+                        }
+                        placeholder={`선택지 ${index + 1}`}
+                        className="border-0 bg-transparent shadow-none focus-visible:ring-0"
+                      />
+                      <Button
+                        variant="gray-outline"
+                        size="sm"
+                        onClick={() => removeOption(index)}
+                        disabled={options.length <= 2}
+                        className="h-8 w-8 min-w-0 p-0"
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
                     </div>
-                  )}
-              </>
-            ) : (
-              <div className="text-sm text-text-subtitle">
-                아직 생성된 투표 라운드가 없습니다.
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>학생 초대 QR</CardTitle>
-          </CardHeader>
-          <CardContent className="flex flex-col items-center gap-3">
-            <QRCodeCanvas
-              value={`${origin}/vote/student/${roomId}`}
-              size={220}
-            />
-            <div className="text-xs text-text-subtitle break-all">
-              {origin}/vote/student/{roomId}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {!currentRound && (
-        <Card>
-          <CardHeader>
-            <CardTitle>새 투표 만들기</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Textarea
-              placeholder="질문을 입력하세요."
-              value={question}
-              onChange={(event) => setQuestion(event.target.value)}
-            />
-            <div className="space-y-2">
-              {options.map((option, index) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <div key={index} className="flex gap-2">
-                  <Input
-                    value={option}
-                    onChange={(event) =>
-                      updateOptionValue(index, event.target.value)
-                    }
-                    placeholder={`선택지 ${index + 1}`}
-                  />
+                  ))}
                   <Button
                     variant="gray-outline"
                     size="sm"
-                    onClick={() => removeOption(index)}
-                    disabled={options.length <= 2}
+                    onClick={addOption}
+                    disabled={options.length >= MAX_VOTE_OPTIONS}
+                    className="w-full border-dashed"
                   >
-                    <Trash2 className="size-4" />
+                    <Plus className="size-4 mr-1" />
+                    선택지 추가 ({options.length}/{MAX_VOTE_OPTIONS})
                   </Button>
                 </div>
-              ))}
-              <Button
-                variant="gray-outline"
-                size="sm"
-                onClick={addOption}
-                disabled={options.length >= MAX_VOTE_OPTIONS}
-              >
-                <Plus className="size-4 mr-1" />
-                선택지 추가 ({options.length}/{MAX_VOTE_OPTIONS})
-              </Button>
-            </div>
 
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="max-selections">학생 최대 선택 가능 개수</Label>
-              <Input
-                id="max-selections"
-                type="number"
-                min={1}
-                max={Math.max(
-                  1,
-                  options.filter((value) => value.trim()).length,
-                )}
-                value={maxSelections}
-                onChange={(event) => {
-                  const value = Number(event.target.value);
-                  if (!Number.isNaN(value)) {
-                    setMaxSelections(Math.max(1, value));
-                  }
-                }}
-              />
-            </div>
-
-            {errorMessage && <p className="text-sm text-red">{errorMessage}</p>}
-
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => createRound(options)}
-              isPending={isRoundCreating}
-            >
-              투표 라운드 만들기
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-
-      {snapshot.room.status === 'ended' && resultSourceRound && (
-        <Card>
-          <CardHeader>
-            <CardTitle>최종 결과 Top 3</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {top3.length === 0 ? (
-              <div className="text-sm text-text-subtitle">
-                집계된 결과가 없습니다.
-              </div>
-            ) : (
-              top3.map((option, index) => (
-                <div
-                  key={option.id}
-                  className="flex items-center justify-between border-b dark:border-gray-700 pb-2"
-                >
-                  <div className="font-medium text-text-title">
-                    {index + 1}위. {option.label}
-                  </div>
-                  <Badge>{option.voteCount}표</Badge>
+                <div className="flex flex-col gap-3">
+                  {errorMessage && (
+                    <p className="text-sm text-red">{errorMessage}</p>
+                  )}
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => createRound(options)}
+                    isPending={isRoundCreating}
+                    className="w-full"
+                  >
+                    만들기
+                  </Button>
                 </div>
-              ))
-            )}
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => {
-                router.push('/vote');
-              }}
-            >
-              새로운 투표 만들기
-            </Button>
-          </CardContent>
-        </Card>
-      )}
+              </CardContent>
+            </Card>
+          )}
+
+          {snapshot.room.status === 'ended' && resultSourceRound && (
+            <Card className="border-primary-100/70 dark:border-gray-800 shadow-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>최종 결과 Top 3</span>
+                  <Badge variant="primary-outline">
+                    총 {resultSourceRound.totalVotes}표
+                  </Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {top3.length === 0 ? (
+                  <div className="text-sm text-text-subtitle">
+                    집계된 결과가 없습니다.
+                  </div>
+                ) : (
+                  top3.map((option, index) => (
+                    <div
+                      key={option.id}
+                      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-3 py-3"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary text-xs font-semibold px-1">
+                            {index + 1}
+                          </span>
+                          <div className="font-medium text-text-title truncate">
+                            {option.label}
+                          </div>
+                        </div>
+                        <Badge variant="gray-outline">
+                          {option.voteCount}표
+                        </Badge>
+                      </div>
+                    </div>
+                  ))
+                )}
+                <Button
+                  variant="primary"
+                  size="sm"
+                  className="w-full h-11"
+                  onClick={() => {
+                    router.push('/vote');
+                  }}
+                >
+                  새로운 투표 만들기
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        <div className="xl:sticky xl:top-12">
+          <Card className="shadow-sm">
+            <CardHeader>
+              <CardTitle>학생 초대 QR</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col items-center gap-3">
+              <div
+                ref={qrContainerRef}
+                className="rounded-xl bg-white p-3 dark:bg-gray-950 border dark:border-gray-800"
+              >
+                <QRCodeCanvas value={inviteUrl} size={300} />
+              </div>
+              <div className="text-xs text-text-subtitle break-all text-center">
+                {inviteUrl}
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 w-full">
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="gray-outline"
+                      size="sm"
+                      className="w-full"
+                    >
+                      <ZoomIn className="size-4 mr-1" />
+                      크게 보기
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent className="max-w-[92vw] sm:max-w-2xl p-6">
+                    <DialogTitle className="text-center">
+                      학생 초대 QR 코드
+                    </DialogTitle>
+                    <div className="flex justify-center">
+                      <div className="rounded-xl bg-white p-3 border dark:border-gray-800">
+                        <QRCodeCanvas value={inviteUrl} size={520} />
+                      </div>
+                    </div>
+                    <p className="text-xs text-text-subtitle break-all text-center">
+                      {inviteUrl}
+                    </p>
+                  </DialogContent>
+                </Dialog>
+
+                <Button
+                  type="button"
+                  variant="gray-outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={openQrInPopupWindow}
+                >
+                  <ExternalLink className="size-4 mr-1" />새 창으로 보기
+                </Button>
+
+                <Button
+                  type="button"
+                  variant="gray-outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={copyInviteUrl}
+                >
+                  <Copy className="size-4 mr-1" />
+                  URL 복사
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/containers/vote/vote-teacher/vote-teacher-container.tsx
+++ b/src/containers/vote/vote-teacher/vote-teacher-container.tsx
@@ -24,6 +24,7 @@ import { Badge } from '@/components/badge';
 import { useGetVoteTeacherSnapshot } from '@/hooks/apis/vote/use-get-vote-snapshot';
 import { useVoteRealtime } from '@/hooks/apis/vote/use-vote-realtime';
 import { useCreateVoteRound } from '@/hooks/apis/vote/use-create-vote-round';
+import { useUpdateReadyVoteRound } from '@/hooks/apis/vote/use-update-ready-vote-round';
 import { useStartVoteRound } from '@/hooks/apis/vote/use-start-vote-round';
 import { useEndVoteRound } from '@/hooks/apis/vote/use-end-vote-round';
 import { useFinishVoteRoom } from '@/hooks/apis/vote/use-finish-vote-room';
@@ -44,6 +45,18 @@ type Props = {
 };
 
 const DEFAULT_OPTIONS = ['', ''];
+const RESULT_CHART_COLORS = [
+  '#93c5fd',
+  '#c4b5fd',
+  '#86efac',
+  '#fcd34d',
+  '#fca5a5',
+  '#67e8f9',
+  '#bef264',
+  '#fdba74',
+  '#a5b4fc',
+  '#f9a8d4',
+];
 type RevoteOptionItem = {
   id: string;
   label: string;
@@ -68,9 +81,16 @@ export default function VoteTeacherContainer({ params }: Props) {
   const [origin, setOrigin] = useState('');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [isCreatingRevote, setIsCreatingRevote] = useState(false);
+  const [isEditingReadyRound, setIsEditingReadyRound] = useState(false);
+  const [isResultDialogOpen, setIsResultDialogOpen] = useState(false);
+  const [resultDialogView, setResultDialogView] = useState<'pie' | 'bar'>(
+    'pie',
+  );
 
   const { mutate: createVoteRoundMutation, isPending: isRoundCreating } =
     useCreateVoteRound();
+  const { mutate: updateReadyVoteRoundMutation, isPending: isRoundUpdating } =
+    useUpdateReadyVoteRound();
   const { mutate: startVoteRoundMutation, isPending: isStarting } =
     useStartVoteRound();
   const { mutate: endVoteRoundMutation, isPending: isEnding } =
@@ -106,13 +126,130 @@ export default function VoteTeacherContainer({ params }: Props) {
   const resultSourceRound =
     currentRound?.status === 'ended' ? currentRound : latestEndedRound;
 
+  const rankedResultOptions = useMemo(() => {
+    const sortedOptions = [...(resultSourceRound?.options ?? [])].sort(
+      (a, b) => b.voteCount - a.voteCount,
+    );
+
+    let currentRank = 0;
+    let previousVoteCount: number | null = null;
+
+    return sortedOptions.map((option) => {
+      if (
+        previousVoteCount === null ||
+        option.voteCount !== previousVoteCount
+      ) {
+        currentRank += 1;
+        previousVoteCount = option.voteCount;
+      }
+
+      return {
+        ...option,
+        rank: currentRank,
+      };
+    });
+  }, [resultSourceRound]);
   const top3 = useMemo(
-    () =>
-      [...(resultSourceRound?.options ?? [])]
-        .sort((a, b) => b.voteCount - a.voteCount)
-        .slice(0, 3),
-    [resultSourceRound],
+    () => rankedResultOptions.filter((option) => option.rank <= 3),
+    [rankedResultOptions],
   );
+  const chartResultOptions = useMemo(
+    () => rankedResultOptions.filter((option) => option.voteCount > 0),
+    [rankedResultOptions],
+  );
+  const maxRankedVoteCount = useMemo(
+    () => Math.max(...rankedResultOptions.map((option) => option.voteCount), 1),
+    [rankedResultOptions],
+  );
+
+  const rankCountMap = useMemo(
+    () =>
+      rankedResultOptions.reduce<Record<number, number>>(
+        (accumulator, option) => {
+          accumulator[option.rank] = (accumulator[option.rank] ?? 0) + 1;
+          return accumulator;
+        },
+        {},
+      ),
+    [rankedResultOptions],
+  );
+  const pieChartSegments = useMemo(() => {
+    const totalVotes = resultSourceRound?.totalVotes ?? 0;
+    if (chartResultOptions.length === 0 || totalVotes <= 0) {
+      return [];
+    }
+
+    let currentAngle = 0;
+    return chartResultOptions.map((option, index) => {
+      const percentage = (option.voteCount / totalVotes) * 100;
+      const start = currentAngle;
+      const end = currentAngle + percentage;
+      currentAngle = end;
+
+      return {
+        id: option.id,
+        label: option.label,
+        percentage,
+        start,
+        end,
+        color: RESULT_CHART_COLORS[index % RESULT_CHART_COLORS.length],
+      };
+    });
+  }, [chartResultOptions, resultSourceRound]);
+  const pieChartBackground = useMemo(() => {
+    if (chartResultOptions.length === 0) {
+      return 'conic-gradient(#e5e7eb 0 100%)';
+    }
+    if (pieChartSegments.length === 0) {
+      return 'conic-gradient(#e5e7eb 0 100%)';
+    }
+
+    const segments = pieChartSegments.map(
+      (segment) => `${segment.color} ${segment.start}% ${segment.end}%`,
+    );
+
+    return `conic-gradient(${segments.join(', ')})`;
+  }, [chartResultOptions, pieChartSegments]);
+  const validOptionCount = useMemo(
+    () => options.filter((value) => value.trim()).length,
+    [options],
+  );
+  const selectionCountCandidates = useMemo(
+    () => Array.from({ length: MAX_VOTE_OPTIONS - 1 }, (_, index) => index + 1),
+    [],
+  );
+  const createMaxSelectionLimit = Math.min(
+    MAX_VOTE_OPTIONS - 1,
+    Math.max(0, validOptionCount - 1),
+  );
+  const revoteMaxSelectionLimit = Math.min(
+    MAX_VOTE_OPTIONS - 1,
+    Math.max(0, revoteOptionIds.length - 1),
+  );
+
+  useEffect(() => {
+    if (!currentRound || currentRound.status !== 'ready') {
+      setIsEditingReadyRound(false);
+    }
+  }, [currentRound]);
+
+  useEffect(() => {
+    if (createMaxSelectionLimit <= 0) {
+      setMaxSelections(1);
+      return;
+    }
+    setMaxSelections((previous) => Math.min(previous, createMaxSelectionLimit));
+  }, [createMaxSelectionLimit]);
+
+  useEffect(() => {
+    if (revoteMaxSelectionLimit <= 0) {
+      setRevoteMaxSelections(1);
+      return;
+    }
+    setRevoteMaxSelections((previous) =>
+      Math.min(previous, revoteMaxSelectionLimit),
+    );
+  }, [revoteMaxSelectionLimit]);
 
   const updateOptionValue = (index: number, value: string) => {
     setOptions((previous) => {
@@ -138,7 +275,10 @@ export default function VoteTeacherContainer({ params }: Props) {
       }
 
       const next = previous.filter((_, idx) => idx !== index);
-      setMaxSelections((oldValue) => Math.min(oldValue, next.length));
+      const nextValidOptionCount = next.filter((value) => value.trim()).length;
+      setMaxSelections((oldValue) =>
+        Math.min(oldValue, Math.max(1, nextValidOptionCount - 1)),
+      );
       return next;
     });
   };
@@ -159,8 +299,10 @@ export default function VoteTeacherContainer({ params }: Props) {
       return;
     }
 
-    if (maxSelections > trimmedOptions.length) {
-      setErrorMessage('최대 선택 개수는 선택지 개수를 넘을 수 없습니다.');
+    if (maxSelections > trimmedOptions.length - 1) {
+      setErrorMessage(
+        '최대 선택 개수는 유효한 선택지 개수보다 1개 적어야 합니다.',
+      );
       return;
     }
 
@@ -183,6 +325,67 @@ export default function VoteTeacherContainer({ params }: Props) {
           setRevoteQuestion('');
           setRevoteMaxSelections(1);
           setIsCreatingRevote(false);
+          refetch();
+        },
+        onError: (error) => {
+          setErrorMessage(error.message);
+        },
+      },
+    );
+  };
+
+  const initializeReadyRoundEditForm = () => {
+    if (!currentRound || currentRound.status !== 'ready') return;
+
+    setQuestion(currentRound.question);
+    setOptions(currentRound.options.map((option) => option.label));
+    setMaxSelections(
+      Math.min(
+        Math.max(1, currentRound.maxSelections),
+        Math.max(1, currentRound.options.length - 1),
+      ),
+    );
+    setIsEditingReadyRound(true);
+    setErrorMessage('');
+  };
+
+  const saveReadyRound = (nextOptions: string[]) => {
+    if (!currentRound || currentRound.status !== 'ready') return;
+
+    const trimmedQuestion = question.trim();
+    const trimmedOptions = nextOptions
+      .map((option) => option.trim())
+      .filter(Boolean);
+
+    if (!trimmedQuestion) {
+      setErrorMessage('질문을 입력해주세요.');
+      return;
+    }
+
+    if (trimmedOptions.length < 2) {
+      setErrorMessage('선택지는 최소 2개가 필요합니다.');
+      return;
+    }
+
+    if (maxSelections > trimmedOptions.length - 1) {
+      setErrorMessage(
+        '최대 선택 개수는 유효한 선택지 개수보다 1개 적어야 합니다.',
+      );
+      return;
+    }
+
+    setErrorMessage('');
+    updateReadyVoteRoundMutation(
+      {
+        roomId,
+        roundId: currentRound.id,
+        question: trimmedQuestion,
+        maxSelections,
+        options: trimmedOptions,
+      },
+      {
+        onSuccess: () => {
+          setIsEditingReadyRound(false);
           refetch();
         },
         onError: (error) => {
@@ -236,7 +439,7 @@ export default function VoteTeacherContainer({ params }: Props) {
     setRevoteOptionIds([]);
     setRevoteOptionDraft('');
     setRevoteQuestion(currentRound.question);
-    setRevoteMaxSelections(Math.max(1, currentRound.maxSelections));
+    setRevoteMaxSelections(1);
   };
 
   const addRevoteOption = () => {
@@ -303,8 +506,10 @@ export default function VoteTeacherContainer({ params }: Props) {
       return;
     }
 
-    if (revoteMaxSelections > revoteOptionIds.length) {
-      setErrorMessage('최대 선택 개수는 선택지 개수를 넘을 수 없습니다.');
+    if (revoteMaxSelections > revoteOptionIds.length - 1) {
+      setErrorMessage(
+        '최대 선택 개수는 선택한 선택지 개수보다 1개 적어야 합니다.',
+      );
       return;
     }
 
@@ -520,56 +725,77 @@ export default function VoteTeacherContainer({ params }: Props) {
 
               {currentRound ? (
                 <>
-                  <div className="rounded-xl border border-primary-100 dark:border-gray-800 p-4 bg-white dark:bg-gray-950">
-                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                      <Heading3 className="text-base leading-relaxed tracking-tight">
-                        {currentRound.question}
-                      </Heading3>
-                      <div className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold bg-primary-50 text-primary-700 dark:bg-primary-900/20 dark:text-primary-200 whitespace-nowrap">
-                        최대 선택 {currentRound.maxSelections}개
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="space-y-3">
-                    {currentRound.options.map((option) => {
-                      const totalVotes = Math.max(currentRound.totalVotes, 1);
-                      const ratio = Math.round(
-                        (option.voteCount / totalVotes) * 100,
-                      );
-                      return (
-                        <div
-                          key={option.id}
-                          className="space-y-2 rounded-lg border border-gray-200 dark:border-gray-800 px-3 py-4 bg-white dark:bg-gray-950"
-                        >
-                          <div className="flex justify-between text-sm items-center gap-2">
-                            <span className="font-medium leading-5">
-                              {option.label}
-                            </span>
-                            <span className="text-text-subtitle whitespace-nowrap text-xs">
-                              {option.voteCount}표 · {ratio}%
-                            </span>
-                          </div>
-                          <div className="w-full h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
-                            <div
-                              className="h-full bg-primary transition-all duration-300"
-                              style={{ width: `${ratio}%` }}
-                            />
+                  {snapshot.room.status !== 'ended' ? (
+                    <>
+                      <div className="rounded-xl border border-primary-100 dark:border-gray-800 p-4 bg-white dark:bg-gray-950">
+                        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                          <Heading3 className="text-base leading-relaxed tracking-tight">
+                            {currentRound.question}
+                          </Heading3>
+                          <div className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold bg-primary-50 text-primary-700 dark:bg-primary-900/20 dark:text-primary-200 whitespace-nowrap">
+                            최대 선택 {currentRound.maxSelections}개
                           </div>
                         </div>
-                      );
-                    })}
-                  </div>
+                      </div>
+
+                      <div className="space-y-3">
+                        {currentRound.options.map((option) => {
+                          const totalVotes = Math.max(
+                            currentRound.totalVotes,
+                            1,
+                          );
+                          const ratio = Math.round(
+                            (option.voteCount / totalVotes) * 100,
+                          );
+                          return (
+                            <div
+                              key={option.id}
+                              className="space-y-2 rounded-lg border border-gray-200 dark:border-gray-800 px-3 py-4 bg-white dark:bg-gray-950"
+                            >
+                              <div className="flex justify-between text-sm items-center gap-2">
+                                <span className="font-medium leading-5">
+                                  {option.label}
+                                </span>
+                                <span className="text-text-subtitle whitespace-nowrap text-xs">
+                                  {option.voteCount}표 · {ratio}%
+                                </span>
+                              </div>
+                              <div className="w-full h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                                <div
+                                  className="h-full bg-primary transition-all duration-300"
+                                  style={{ width: `${ratio}%` }}
+                                />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </>
+                  ) : (
+                    <div className="rounded-lg border border-dashed border-gray-200 dark:border-gray-700 px-4 py-3 text-sm text-text-subtitle">
+                      투표가 종료되어 질문/선택지 상세는 숨겨집니다. 결과
+                      보기에서 전체 결과를 확인해주세요.
+                    </div>
+                  )}
 
                   {currentRound.status === 'ready' && (
-                    <Button
-                      variant="primary"
-                      onClick={handleStartRound}
-                      isPending={isStarting}
-                      className="w-full h-11"
-                    >
-                      투표 시작하기
-                    </Button>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      <Button
+                        variant="gray-outline"
+                        onClick={initializeReadyRoundEditForm}
+                        className="w-full h-11"
+                      >
+                        수정하기
+                      </Button>
+                      <Button
+                        variant="primary"
+                        onClick={handleStartRound}
+                        isPending={isStarting}
+                        className="w-full h-11"
+                      >
+                        투표 시작하기
+                      </Button>
+                    </div>
                   )}
 
                   {currentRound.status === 'live' && (
@@ -640,27 +866,36 @@ export default function VoteTeacherContainer({ params }: Props) {
                                 />
                               </div>
                               <div className="space-y-2">
-                                <Label
-                                  htmlFor="revote-max-selections"
-                                  className="text-sm font-semibold text-text-title"
-                                >
+                                <Label className="text-sm font-semibold text-text-title">
                                   최대 선택 개수
                                 </Label>
-                                <Input
-                                  id="revote-max-selections"
-                                  type="number"
-                                  min={1}
-                                  max={Math.max(1, revoteOptionIds.length)}
-                                  value={revoteMaxSelections}
-                                  onChange={(event) => {
-                                    const value = Number(event.target.value);
-                                    if (!Number.isNaN(value)) {
-                                      setRevoteMaxSelections(
-                                        Math.max(1, value),
-                                      );
-                                    }
-                                  }}
-                                />
+                                <div className="grid grid-cols-5 gap-2">
+                                  {selectionCountCandidates.map((count) => {
+                                    const isEnabled =
+                                      count <= revoteMaxSelectionLimit;
+                                    const isActive =
+                                      isEnabled &&
+                                      revoteMaxSelections === count;
+
+                                    return (
+                                      <Button
+                                        key={count}
+                                        type="button"
+                                        variant={
+                                          isActive ? 'primary' : 'gray-outline'
+                                        }
+                                        size="sm"
+                                        className="h-9"
+                                        disabled={!isEnabled}
+                                        onClick={() =>
+                                          setRevoteMaxSelections(count)
+                                        }
+                                      >
+                                        {count}
+                                      </Button>
+                                    );
+                                  })}
+                                </div>
                               </div>
                             </div>
 
@@ -676,59 +911,81 @@ export default function VoteTeacherContainer({ params }: Props) {
                               </div>
 
                               <div className="grid grid-cols-1 gap-3">
-                                {revoteOptions.map((option, index) => (
-                                  <div
-                                    key={option.id}
-                                    role="button"
-                                    tabIndex={0}
-                                    onClick={() =>
-                                      toggleRevoteOption(option.id)
-                                    }
-                                    onKeyDown={(event) => {
-                                      if (
-                                        event.key === 'Enter' ||
-                                        event.key === ' '
-                                      ) {
-                                        event.preventDefault();
-                                        toggleRevoteOption(option.id);
+                                {revoteOptions.map((option, index) => {
+                                  const originalOption =
+                                    currentRound.options.find(
+                                      (item) => item.id === option.id,
+                                    );
+                                  const voteCount =
+                                    originalOption?.voteCount ?? 0;
+                                  const voteRatio =
+                                    currentRound.totalVotes > 0
+                                      ? Math.round(
+                                          (voteCount /
+                                            currentRound.totalVotes) *
+                                            100,
+                                        )
+                                      : 0;
+
+                                  return (
+                                    <div
+                                      key={option.id}
+                                      role="button"
+                                      tabIndex={0}
+                                      onClick={() =>
+                                        toggleRevoteOption(option.id)
                                       }
-                                    }}
-                                    className="flex min-h-12 items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-2 py-2 cursor-pointer"
-                                  >
-                                    <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary text-xs font-semibold px-1">
-                                      {index + 1}
-                                    </span>
-                                    <div className="flex items-center gap-2 flex-1 min-w-0">
-                                      <Checkbox
-                                        checked={revoteOptionIds.includes(
-                                          option.id,
-                                        )}
-                                        onCheckedChange={() =>
-                                          toggleRevoteOption(option.id)
+                                      onKeyDown={(event) => {
+                                        if (
+                                          event.key === 'Enter' ||
+                                          event.key === ' '
+                                        ) {
+                                          event.preventDefault();
+                                          toggleRevoteOption(option.id);
                                         }
-                                        className="pointer-events-none"
-                                      />
-                                      <span className="truncate">
-                                        {option.label}
+                                      }}
+                                      className="flex min-h-12 items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-2 py-2 cursor-pointer"
+                                    >
+                                      <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary text-xs font-semibold px-1">
+                                        {index + 1}
                                       </span>
+                                      <div className="flex items-center gap-2 flex-1 min-w-0">
+                                        <Checkbox
+                                          checked={revoteOptionIds.includes(
+                                            option.id,
+                                          )}
+                                          onCheckedChange={() =>
+                                            toggleRevoteOption(option.id)
+                                          }
+                                          className="pointer-events-none"
+                                        />
+                                        <span className="truncate">
+                                          {option.label}
+                                        </span>
+                                        <span className="text-[11px] text-text-subtitle whitespace-nowrap">
+                                          {option.isCustom
+                                            ? '신규 선택지'
+                                            : `${voteCount}표 · ${voteRatio}%`}
+                                        </span>
+                                      </div>
+                                      {option.isCustom && (
+                                        <Button
+                                          type="button"
+                                          variant="gray-outline"
+                                          size="sm"
+                                          onClick={(event) => {
+                                            event.stopPropagation();
+                                            removeRevoteOption(option.id);
+                                          }}
+                                          className="h-8 w-8 min-w-0 p-0"
+                                          aria-label="추가한 선택지 삭제"
+                                        >
+                                          <Trash2 className="size-4" />
+                                        </Button>
+                                      )}
                                     </div>
-                                    {option.isCustom && (
-                                      <Button
-                                        type="button"
-                                        variant="gray-outline"
-                                        size="sm"
-                                        onClick={(event) => {
-                                          event.stopPropagation();
-                                          removeRevoteOption(option.id);
-                                        }}
-                                        className="h-8 w-8 min-w-0 p-0"
-                                        aria-label="추가한 선택지 삭제"
-                                      >
-                                        <Trash2 className="size-4" />
-                                      </Button>
-                                    )}
-                                  </div>
-                                ))}
+                                  );
+                                })}
                               </div>
 
                               <div className="flex min-h-10 items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-2 py-2">
@@ -783,10 +1040,12 @@ export default function VoteTeacherContainer({ params }: Props) {
             </CardContent>
           </Card>
 
-          {!currentRound && (
+          {(!currentRound || isEditingReadyRound) && (
             <Card className="border-primary-100/70 dark:border-gray-800 shadow-sm">
               <CardHeader>
-                <CardTitle>투표 만들기</CardTitle>
+                <CardTitle>
+                  {isEditingReadyRound ? '투표 수정하기' : '투표 만들기'}
+                </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
@@ -803,27 +1062,27 @@ export default function VoteTeacherContainer({ params }: Props) {
                   </div>
 
                   <div className="rounded-lg px-3 py-3 flex flex-col gap-2">
-                    <Label htmlFor="max-selections">최대 선택 개수</Label>
-                    <Input
-                      id="max-selections"
-                      type="number"
-                      min={1}
-                      max={Math.max(
-                        1,
-                        options.filter((value) => value.trim()).length,
-                      )}
-                      value={maxSelections}
-                      onChange={(event) => {
-                        const value = Number(event.target.value);
-                        if (!Number.isNaN(value)) {
-                          setMaxSelections(Math.max(1, value));
-                        }
-                      }}
-                      className="bg-white dark:bg-gray-950"
-                    />
-                    <p className="text-xs text-text-subtitle">
-                      유효한 선택지 수 기준으로 자동 제한됩니다.
-                    </p>
+                    <Label>최대 선택 개수</Label>
+                    <div className="grid grid-cols-5 gap-2">
+                      {selectionCountCandidates.map((count) => {
+                        const isEnabled = count <= createMaxSelectionLimit;
+                        const isActive = isEnabled && maxSelections === count;
+
+                        return (
+                          <Button
+                            key={count}
+                            type="button"
+                            variant={isActive ? 'primary' : 'gray-outline'}
+                            size="sm"
+                            className="h-9"
+                            disabled={!isEnabled}
+                            onClick={() => setMaxSelections(count)}
+                          >
+                            {count}
+                          </Button>
+                        );
+                      })}
+                    </div>
                   </div>
                 </div>
 
@@ -883,12 +1142,31 @@ export default function VoteTeacherContainer({ params }: Props) {
                   <Button
                     variant="primary"
                     size="sm"
-                    onClick={() => createRound(options)}
-                    isPending={isRoundCreating}
-                    className="w-full"
+                    onClick={() => {
+                      if (isEditingReadyRound) {
+                        saveReadyRound(options);
+                        return;
+                      }
+                      createRound(options);
+                    }}
+                    isPending={isRoundCreating || isRoundUpdating}
+                    className="w-full h-11"
                   >
-                    만들기
+                    {isEditingReadyRound ? '수정 내용 저장' : '만들기'}
                   </Button>
+                  {isEditingReadyRound && (
+                    <Button
+                      variant="gray-outline"
+                      size="sm"
+                      onClick={() => {
+                        setIsEditingReadyRound(false);
+                        setErrorMessage('');
+                      }}
+                      className="w-full h-11"
+                    >
+                      수정 취소
+                    </Button>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -910,7 +1188,7 @@ export default function VoteTeacherContainer({ params }: Props) {
                     집계된 결과가 없습니다.
                   </div>
                 ) : (
-                  top3.map((option, index) => (
+                  top3.map((option) => (
                     <div
                       key={option.id}
                       className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-3 py-3"
@@ -918,7 +1196,9 @@ export default function VoteTeacherContainer({ params }: Props) {
                       <div className="flex items-center justify-between gap-3">
                         <div className="flex items-center gap-2 min-w-0">
                           <span className="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary text-xs font-semibold px-1">
-                            {index + 1}
+                            {rankCountMap[option.rank] > 1
+                              ? `공동 ${option.rank}`
+                              : `${option.rank}`}
                           </span>
                           <div className="font-medium text-text-title truncate">
                             {option.label}
@@ -931,6 +1211,174 @@ export default function VoteTeacherContainer({ params }: Props) {
                     </div>
                   ))
                 )}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <Button
+                    type="button"
+                    variant="gray-outline"
+                    size="sm"
+                    className="w-full h-11"
+                    onClick={() => {
+                      setResultDialogView('pie');
+                      setIsResultDialogOpen(true);
+                    }}
+                  >
+                    원 그래프로 보기
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="gray-outline"
+                    size="sm"
+                    className="w-full h-11"
+                    onClick={() => {
+                      setResultDialogView('bar');
+                      setIsResultDialogOpen(true);
+                    }}
+                  >
+                    막대 그래프로 보기
+                  </Button>
+                </div>
+
+                <Dialog
+                  open={isResultDialogOpen}
+                  onOpenChange={setIsResultDialogOpen}
+                >
+                  <DialogContent className="max-w-[96vw] lg:max-w-6xl p-6 max-h-[92vh] overflow-y-auto">
+                    <DialogTitle>
+                      {resultDialogView === 'pie'
+                        ? '전체 원 그래프'
+                        : '전체 막대 그래프'}
+                    </DialogTitle>
+                    {resultDialogView === 'pie' &&
+                      chartResultOptions.length === 0 && (
+                        <div className="text-sm text-text-subtitle py-8 text-center">
+                          배정된 득표가 없어 그래프를 표시할 수 없습니다.
+                        </div>
+                      )}
+                    {chartResultOptions.length > 0 &&
+                      resultDialogView === 'pie' && (
+                        <div className="space-y-6">
+                          <div className="flex justify-center">
+                            <div
+                              className="relative size-[min(72vw,520px)] rounded-full border border-gray-200 dark:border-gray-700"
+                              style={{ background: pieChartBackground }}
+                            >
+                              {pieChartSegments.map((segment) => {
+                                const midPoint =
+                                  (segment.start + segment.end) / 2;
+                                const angleInRadians =
+                                  (midPoint / 100) * Math.PI * 2 - Math.PI / 2;
+                                const xPosition =
+                                  50 + Math.cos(angleInRadians) * 34;
+                                const yPosition =
+                                  50 + Math.sin(angleInRadians) * 34;
+
+                                return (
+                                  <div
+                                    key={segment.id}
+                                    className="absolute pointer-events-none text-[13px] leading-tight text-slate-700 dark:text-gray-100 text-center max-w-[110px] -translate-x-1/2 -translate-y-1/2"
+                                    style={{
+                                      left: `${xPosition}%`,
+                                      top: `${yPosition}%`,
+                                    }}
+                                  >
+                                    <div className="truncate font-semibold">
+                                      {segment.label}
+                                    </div>
+                                    <div>{Math.round(segment.percentage)}%</div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                          <div className="w-full grid grid-cols-1 sm:grid-cols-2 gap-2">
+                            {chartResultOptions.map((option, index) => {
+                              const percentage =
+                                resultSourceRound.totalVotes > 0
+                                  ? Math.round(
+                                      (option.voteCount /
+                                        resultSourceRound.totalVotes) *
+                                        100,
+                                    )
+                                  : 0;
+                              return (
+                                <div
+                                  key={option.id}
+                                  className="flex items-center gap-2 text-sm"
+                                >
+                                  <span
+                                    className="size-2.5 rounded-full"
+                                    style={{
+                                      backgroundColor:
+                                        RESULT_CHART_COLORS[
+                                          index % RESULT_CHART_COLORS.length
+                                        ],
+                                    }}
+                                  />
+                                  <span className="truncate flex-1">
+                                    {option.label}
+                                  </span>
+                                  <span className="text-text-subtitle">
+                                    {percentage}%
+                                  </span>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+                    {rankedResultOptions.length > 0 &&
+                      resultDialogView === 'bar' && (
+                        <div className="space-y-3">
+                          <p className="text-xs text-text-subtitle">
+                            총 {resultSourceRound.totalVotes}표 기준
+                          </p>
+                          <div className="h-[65vh]">
+                            <div
+                              className="h-full w-full grid items-end gap-3"
+                              style={{
+                                gridTemplateColumns: `repeat(${Math.max(rankedResultOptions.length, 1)}, minmax(0, 1fr))`,
+                              }}
+                            >
+                              {rankedResultOptions.map((option, index) => {
+                                const heightRatio = Math.max(
+                                  8,
+                                  Math.round(
+                                    (option.voteCount / maxRankedVoteCount) *
+                                      100,
+                                  ),
+                                );
+                                return (
+                                  <div
+                                    key={option.id}
+                                    className="h-full min-w-0 flex flex-col items-center gap-2"
+                                  >
+                                    <span className="h-5 inline-flex items-center text-sm text-text-subtitle">
+                                      {option.voteCount}표
+                                    </span>
+                                    <div className="h-[78%] w-full flex items-end">
+                                      <div
+                                        className="w-full rounded-t-md border border-black/10 dark:border-white/10 transition-all"
+                                        style={{
+                                          height: `${heightRatio}%`,
+                                          backgroundColor:
+                                            RESULT_CHART_COLORS[
+                                              index % RESULT_CHART_COLORS.length
+                                            ],
+                                        }}
+                                      />
+                                    </div>
+                                    <span className="h-8 inline-flex items-start justify-center text-xs text-text-subtitle truncate w-full text-center leading-4">
+                                      {option.label}
+                                    </span>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                  </DialogContent>
+                </Dialog>
                 <Button
                   variant="primary"
                   size="sm"

--- a/src/containers/vote/vote-teacher/vote-teacher-container.tsx
+++ b/src/containers/vote/vote-teacher/vote-teacher-container.tsx
@@ -12,7 +12,6 @@ import { Checkbox } from '@/components/checkbox';
 import { Label } from '@/components/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/card';
 import { Badge } from '@/components/badge';
-import useLocalStorage from '@/hooks/useLocalStorage';
 import { useGetVoteTeacherSnapshot } from '@/hooks/apis/vote/use-get-vote-snapshot';
 import { useVoteRealtime } from '@/hooks/apis/vote/use-vote-realtime';
 import { useCreateVoteRound } from '@/hooks/apis/vote/use-create-vote-round';
@@ -20,7 +19,7 @@ import { useStartVoteRound } from '@/hooks/apis/vote/use-start-vote-round';
 import { useEndVoteRound } from '@/hooks/apis/vote/use-end-vote-round';
 import { useFinishVoteRoom } from '@/hooks/apis/vote/use-finish-vote-room';
 import { VoteTeacherSnapshot } from '@/apis/vote/vote';
-import { MAX_VOTE_OPTIONS, VOTE_LOCAL_STORAGE_KEYS } from '../vote-constants';
+import { MAX_VOTE_OPTIONS } from '../vote-constants';
 
 type Props = {
   params: {
@@ -33,10 +32,6 @@ const DEFAULT_OPTIONS = ['', ''];
 export default function VoteTeacherContainer({ params }: Props) {
   const { roomId } = params;
   const router = useRouter();
-  const [, setActiveRoomId] = useLocalStorage<string>(
-    VOTE_LOCAL_STORAGE_KEYS.ACTIVE_ROOM_ID,
-    '',
-  );
   const { data, refetch } = useGetVoteTeacherSnapshot({ roomId });
   const [snapshot, setSnapshot] = useState<VoteTeacherSnapshot | null>(null);
   const [question, setQuestion] = useState('');
@@ -67,10 +62,6 @@ export default function VoteTeacherContainer({ params }: Props) {
       setSnapshot(data);
     }
   }, [data]);
-
-  useEffect(() => {
-    setActiveRoomId(roomId);
-  }, [roomId, setActiveRoomId]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -195,7 +186,6 @@ export default function VoteTeacherContainer({ params }: Props) {
       { roomId },
       {
         onSuccess: () => {
-          setActiveRoomId('');
           refetch();
         },
       },
@@ -433,7 +423,7 @@ export default function VoteTeacherContainer({ params }: Props) {
             <div className="space-y-2">
               {options.map((option, index) => (
                 // eslint-disable-next-line react/no-array-index-key
-                <div key={`${index}-${option}`} className="flex gap-2">
+                <div key={index} className="flex gap-2">
                   <Input
                     value={option}
                     onChange={(event) =>
@@ -523,7 +513,6 @@ export default function VoteTeacherContainer({ params }: Props) {
               variant="primary"
               size="sm"
               onClick={() => {
-                setActiveRoomId('');
                 router.push('/vote');
               }}
             >

--- a/src/containers/vote/vote-teacher/vote-teacher-container.tsx
+++ b/src/containers/vote/vote-teacher/vote-teacher-container.tsx
@@ -124,7 +124,13 @@ export default function VoteTeacherContainer({ params }: Props) {
     [snapshot],
   );
   const resultSourceRound =
-    currentRound?.status === 'ended' ? currentRound : latestEndedRound;
+    currentRound && currentRound.status !== 'ready'
+      ? currentRound
+      : latestEndedRound;
+  const showResultCard =
+    Boolean(resultSourceRound) && snapshot?.room.status === 'ended';
+  const isLiveResultView = currentRound?.status === 'live';
+  const canOpenResultCharts = Boolean(resultSourceRound);
 
   const rankedResultOptions = useMemo(() => {
     const sortedOptions = [...(resultSourceRound?.options ?? [])].sort(
@@ -178,7 +184,6 @@ export default function VoteTeacherContainer({ params }: Props) {
     if (chartResultOptions.length === 0 || totalVotes <= 0) {
       return [];
     }
-
     let currentAngle = 0;
     return chartResultOptions.map((option, index) => {
       const percentage = (option.voteCount / totalVotes) * 100;
@@ -189,6 +194,7 @@ export default function VoteTeacherContainer({ params }: Props) {
       return {
         id: option.id,
         label: option.label,
+        voteCount: option.voteCount,
         percentage,
         start,
         end,
@@ -197,9 +203,6 @@ export default function VoteTeacherContainer({ params }: Props) {
     });
   }, [chartResultOptions, resultSourceRound]);
   const pieChartBackground = useMemo(() => {
-    if (chartResultOptions.length === 0) {
-      return 'conic-gradient(#e5e7eb 0 100%)';
-    }
     if (pieChartSegments.length === 0) {
       return 'conic-gradient(#e5e7eb 0 100%)';
     }
@@ -209,7 +212,7 @@ export default function VoteTeacherContainer({ params }: Props) {
     );
 
     return `conic-gradient(${segments.join(', ')})`;
-  }, [chartResultOptions, pieChartSegments]);
+  }, [pieChartSegments]);
   const validOptionCount = useMemo(
     () => options.filter((value) => value.trim()).length,
     [options],
@@ -1172,11 +1175,13 @@ export default function VoteTeacherContainer({ params }: Props) {
             </Card>
           )}
 
-          {snapshot.room.status === 'ended' && resultSourceRound && (
+          {showResultCard && resultSourceRound && (
             <Card className="border-primary-100/70 dark:border-gray-800 shadow-sm">
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
-                  <span>최종 결과 Top 3</span>
+                  <span>
+                    {isLiveResultView ? '실시간 결과 Top 3' : '최종 결과 Top 3'}
+                  </span>
                   <Badge variant="primary-outline">
                     총 {resultSourceRound.totalVotes}표
                   </Badge>
@@ -1211,184 +1216,18 @@ export default function VoteTeacherContainer({ params }: Props) {
                     </div>
                   ))
                 )}
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {snapshot.room.status === 'ended' && (
                   <Button
-                    type="button"
-                    variant="gray-outline"
+                    variant="primary"
                     size="sm"
                     className="w-full h-11"
                     onClick={() => {
-                      setResultDialogView('pie');
-                      setIsResultDialogOpen(true);
+                      router.push('/vote');
                     }}
                   >
-                    원 그래프로 보기
+                    새로운 투표 만들기
                   </Button>
-                  <Button
-                    type="button"
-                    variant="gray-outline"
-                    size="sm"
-                    className="w-full h-11"
-                    onClick={() => {
-                      setResultDialogView('bar');
-                      setIsResultDialogOpen(true);
-                    }}
-                  >
-                    막대 그래프로 보기
-                  </Button>
-                </div>
-
-                <Dialog
-                  open={isResultDialogOpen}
-                  onOpenChange={setIsResultDialogOpen}
-                >
-                  <DialogContent className="max-w-[96vw] lg:max-w-6xl p-6 max-h-[92vh] overflow-y-auto">
-                    <DialogTitle>
-                      {resultDialogView === 'pie'
-                        ? '전체 원 그래프'
-                        : '전체 막대 그래프'}
-                    </DialogTitle>
-                    {resultDialogView === 'pie' &&
-                      chartResultOptions.length === 0 && (
-                        <div className="text-sm text-text-subtitle py-8 text-center">
-                          배정된 득표가 없어 그래프를 표시할 수 없습니다.
-                        </div>
-                      )}
-                    {chartResultOptions.length > 0 &&
-                      resultDialogView === 'pie' && (
-                        <div className="space-y-6">
-                          <div className="flex justify-center">
-                            <div
-                              className="relative size-[min(72vw,520px)] rounded-full border border-gray-200 dark:border-gray-700"
-                              style={{ background: pieChartBackground }}
-                            >
-                              {pieChartSegments.map((segment) => {
-                                const midPoint =
-                                  (segment.start + segment.end) / 2;
-                                const angleInRadians =
-                                  (midPoint / 100) * Math.PI * 2 - Math.PI / 2;
-                                const xPosition =
-                                  50 + Math.cos(angleInRadians) * 34;
-                                const yPosition =
-                                  50 + Math.sin(angleInRadians) * 34;
-
-                                return (
-                                  <div
-                                    key={segment.id}
-                                    className="absolute pointer-events-none text-[13px] leading-tight text-slate-700 dark:text-gray-100 text-center max-w-[110px] -translate-x-1/2 -translate-y-1/2"
-                                    style={{
-                                      left: `${xPosition}%`,
-                                      top: `${yPosition}%`,
-                                    }}
-                                  >
-                                    <div className="truncate font-semibold">
-                                      {segment.label}
-                                    </div>
-                                    <div>{Math.round(segment.percentage)}%</div>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          </div>
-                          <div className="w-full grid grid-cols-1 sm:grid-cols-2 gap-2">
-                            {chartResultOptions.map((option, index) => {
-                              const percentage =
-                                resultSourceRound.totalVotes > 0
-                                  ? Math.round(
-                                      (option.voteCount /
-                                        resultSourceRound.totalVotes) *
-                                        100,
-                                    )
-                                  : 0;
-                              return (
-                                <div
-                                  key={option.id}
-                                  className="flex items-center gap-2 text-sm"
-                                >
-                                  <span
-                                    className="size-2.5 rounded-full"
-                                    style={{
-                                      backgroundColor:
-                                        RESULT_CHART_COLORS[
-                                          index % RESULT_CHART_COLORS.length
-                                        ],
-                                    }}
-                                  />
-                                  <span className="truncate flex-1">
-                                    {option.label}
-                                  </span>
-                                  <span className="text-text-subtitle">
-                                    {percentage}%
-                                  </span>
-                                </div>
-                              );
-                            })}
-                          </div>
-                        </div>
-                      )}
-                    {rankedResultOptions.length > 0 &&
-                      resultDialogView === 'bar' && (
-                        <div className="space-y-3">
-                          <p className="text-xs text-text-subtitle">
-                            총 {resultSourceRound.totalVotes}표 기준
-                          </p>
-                          <div className="h-[65vh]">
-                            <div
-                              className="h-full w-full grid items-end gap-3"
-                              style={{
-                                gridTemplateColumns: `repeat(${Math.max(rankedResultOptions.length, 1)}, minmax(0, 1fr))`,
-                              }}
-                            >
-                              {rankedResultOptions.map((option, index) => {
-                                const heightRatio = Math.max(
-                                  8,
-                                  Math.round(
-                                    (option.voteCount / maxRankedVoteCount) *
-                                      100,
-                                  ),
-                                );
-                                return (
-                                  <div
-                                    key={option.id}
-                                    className="h-full min-w-0 flex flex-col items-center gap-2"
-                                  >
-                                    <span className="h-5 inline-flex items-center text-sm text-text-subtitle">
-                                      {option.voteCount}표
-                                    </span>
-                                    <div className="h-[78%] w-full flex items-end">
-                                      <div
-                                        className="w-full rounded-t-md border border-black/10 dark:border-white/10 transition-all"
-                                        style={{
-                                          height: `${heightRatio}%`,
-                                          backgroundColor:
-                                            RESULT_CHART_COLORS[
-                                              index % RESULT_CHART_COLORS.length
-                                            ],
-                                        }}
-                                      />
-                                    </div>
-                                    <span className="h-8 inline-flex items-start justify-center text-xs text-text-subtitle truncate w-full text-center leading-4">
-                                      {option.label}
-                                    </span>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        </div>
-                      )}
-                  </DialogContent>
-                </Dialog>
-                <Button
-                  variant="primary"
-                  size="sm"
-                  className="w-full h-11"
-                  onClick={() => {
-                    router.push('/vote');
-                  }}
-                >
-                  새로운 투표 만들기
-                </Button>
+                )}
               </CardContent>
             </Card>
           )}
@@ -1460,6 +1299,159 @@ export default function VoteTeacherContainer({ params }: Props) {
               </div>
             </CardContent>
           </Card>
+
+          {canOpenResultCharts && resultSourceRound && (
+            <div className="w-full mt-3 space-y-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <Button
+                  type="button"
+                  variant="gray-outline"
+                  size="sm"
+                  className="w-full h-11"
+                  onClick={() => {
+                    setResultDialogView('pie');
+                    setIsResultDialogOpen(true);
+                  }}
+                >
+                  원 그래프로 보기
+                </Button>
+                <Button
+                  type="button"
+                  variant="gray-outline"
+                  size="sm"
+                  className="w-full h-11"
+                  onClick={() => {
+                    setResultDialogView('bar');
+                    setIsResultDialogOpen(true);
+                  }}
+                >
+                  막대 그래프로 보기
+                </Button>
+              </div>
+              <Dialog
+                open={isResultDialogOpen}
+                onOpenChange={setIsResultDialogOpen}
+              >
+                <DialogContent className="max-w-[96vw] lg:max-w-6xl p-6 max-h-[92vh] overflow-y-auto">
+                  <DialogTitle>
+                    {resultDialogView === 'pie'
+                      ? '전체 원 그래프'
+                      : '전체 막대 그래프'}
+                  </DialogTitle>
+                  {resultDialogView === 'pie' &&
+                    rankedResultOptions.length > 0 && (
+                      <div className="space-y-6">
+                        <div className="flex justify-center">
+                          <div
+                            className="relative size-[min(72vw,520px)] rounded-full border border-gray-200 dark:border-gray-700"
+                            style={{ background: pieChartBackground }}
+                          >
+                            {pieChartSegments.map((segment) => {
+                              const midPoint =
+                                (segment.start + segment.end) / 2;
+                              const angleInRadians =
+                                (midPoint / 100) * Math.PI * 2 - Math.PI / 2;
+                              const xPosition =
+                                50 + Math.cos(angleInRadians) * 34;
+                              const yPosition =
+                                50 + Math.sin(angleInRadians) * 34;
+
+                              return (
+                                <div
+                                  key={segment.id}
+                                  className="absolute pointer-events-none text-[13px] leading-tight text-slate-700 dark:text-gray-100 text-center max-w-[110px] -translate-x-1/2 -translate-y-1/2"
+                                  style={{
+                                    left: `${xPosition}%`,
+                                    top: `${yPosition}%`,
+                                  }}
+                                >
+                                  <div className="truncate font-semibold">
+                                    {segment.label}
+                                  </div>
+                                  <div>
+                                    {Math.round(segment.percentage)}% ·{' '}
+                                    {segment.voteCount}표
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                        <div className="w-full grid grid-cols-1 sm:grid-cols-2 gap-2">
+                          {pieChartSegments.map((segment) => (
+                            <div
+                              key={segment.id}
+                              className="flex items-center gap-2 text-sm"
+                            >
+                              <span
+                                className="size-2.5 rounded-full"
+                                style={{ backgroundColor: segment.color }}
+                              />
+                              <span className="truncate flex-1">
+                                {segment.label}
+                              </span>
+                              <span className="text-text-subtitle">
+                                {Math.round(segment.percentage)}% ·{' '}
+                                {segment.voteCount}표
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  {resultDialogView === 'bar' && (
+                    <div className="space-y-3">
+                      <p className="text-xs text-text-subtitle">
+                        총 {resultSourceRound.totalVotes}표 기준
+                      </p>
+                      <div className="h-[65vh]">
+                        <div
+                          className="h-full w-full grid items-end gap-3"
+                          style={{
+                            gridTemplateColumns: `repeat(${Math.max(rankedResultOptions.length, 1)}, minmax(0, 1fr))`,
+                          }}
+                        >
+                          {rankedResultOptions.map((option, index) => {
+                            const heightRatio = Math.max(
+                              8,
+                              Math.round(
+                                (option.voteCount / maxRankedVoteCount) * 100,
+                              ),
+                            );
+                            return (
+                              <div
+                                key={option.id}
+                                className="h-full min-w-0 flex flex-col items-center gap-2"
+                              >
+                                <span className="h-5 inline-flex items-center text-sm text-text-subtitle">
+                                  {option.voteCount}표
+                                </span>
+                                <div className="h-[78%] w-full flex items-end">
+                                  <div
+                                    className="w-full rounded-t-md border border-black/10 dark:border-white/10 transition-all"
+                                    style={{
+                                      height: `${heightRatio}%`,
+                                      backgroundColor:
+                                        RESULT_CHART_COLORS[
+                                          index % RESULT_CHART_COLORS.length
+                                        ],
+                                    }}
+                                  />
+                                </div>
+                                <span className="h-8 inline-flex items-start justify-center text-xs text-text-subtitle truncate w-full text-center leading-4">
+                                  {option.label}
+                                </span>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </DialogContent>
+              </Dialog>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/containers/vote/vote-teacher/vote-teacher-container.tsx
+++ b/src/containers/vote/vote-teacher/vote-teacher-container.tsx
@@ -1,0 +1,537 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { QRCodeCanvas } from 'qrcode.react';
+import { LoaderCircle, Plus, RefreshCw, Trash2, Users } from 'lucide-react';
+import { Button } from '@/components/button';
+import { Heading1, Heading3 } from '@/components/heading';
+import { Input } from '@/components/input';
+import { Textarea } from '@/components/textarea';
+import { Checkbox } from '@/components/checkbox';
+import { Label } from '@/components/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/card';
+import { Badge } from '@/components/badge';
+import useLocalStorage from '@/hooks/useLocalStorage';
+import { useGetVoteTeacherSnapshot } from '@/hooks/apis/vote/use-get-vote-snapshot';
+import { useVoteRealtime } from '@/hooks/apis/vote/use-vote-realtime';
+import { useCreateVoteRound } from '@/hooks/apis/vote/use-create-vote-round';
+import { useStartVoteRound } from '@/hooks/apis/vote/use-start-vote-round';
+import { useEndVoteRound } from '@/hooks/apis/vote/use-end-vote-round';
+import { useFinishVoteRoom } from '@/hooks/apis/vote/use-finish-vote-room';
+import { VoteTeacherSnapshot } from '@/apis/vote/vote';
+import { MAX_VOTE_OPTIONS, VOTE_LOCAL_STORAGE_KEYS } from '../vote-constants';
+
+type Props = {
+  params: {
+    roomId: string;
+  };
+};
+
+const DEFAULT_OPTIONS = ['', ''];
+
+export default function VoteTeacherContainer({ params }: Props) {
+  const { roomId } = params;
+  const router = useRouter();
+  const [, setActiveRoomId] = useLocalStorage<string>(
+    VOTE_LOCAL_STORAGE_KEYS.ACTIVE_ROOM_ID,
+    '',
+  );
+  const { data, refetch } = useGetVoteTeacherSnapshot({ roomId });
+  const [snapshot, setSnapshot] = useState<VoteTeacherSnapshot | null>(null);
+  const [question, setQuestion] = useState('');
+  const [options, setOptions] = useState<string[]>(DEFAULT_OPTIONS);
+  const [maxSelections, setMaxSelections] = useState(1);
+  const [revoteOptionIds, setRevoteOptionIds] = useState<string[]>([]);
+  const [origin, setOrigin] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [isCreatingRevote, setIsCreatingRevote] = useState(false);
+
+  const { mutate: createVoteRoundMutation, isPending: isRoundCreating } =
+    useCreateVoteRound();
+  const { mutate: startVoteRoundMutation, isPending: isStarting } =
+    useStartVoteRound();
+  const { mutate: endVoteRoundMutation, isPending: isEnding } =
+    useEndVoteRound();
+  const { mutate: finishVoteRoomMutation, isPending: isFinishing } =
+    useFinishVoteRoom();
+
+  const handleSnapshot = useCallback((newSnapshot: VoteTeacherSnapshot) => {
+    setSnapshot(newSnapshot);
+  }, []);
+
+  const [connectionStatus, reconnect] = useVoteRealtime(roomId, handleSnapshot);
+
+  useEffect(() => {
+    if (data) {
+      setSnapshot(data);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    setActiveRoomId(roomId);
+  }, [roomId, setActiveRoomId]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setOrigin(window.location.origin);
+    }
+  }, []);
+
+  const currentRound = snapshot?.currentRound ?? null;
+  const latestEndedRound = useMemo(
+    () => snapshot?.rounds.find((round) => round.status === 'ended') ?? null,
+    [snapshot],
+  );
+  const resultSourceRound =
+    currentRound?.status === 'ended' ? currentRound : latestEndedRound;
+
+  const top3 = useMemo(
+    () =>
+      [...(resultSourceRound?.options ?? [])]
+        .sort((a, b) => b.voteCount - a.voteCount)
+        .slice(0, 3),
+    [resultSourceRound],
+  );
+
+  const updateOptionValue = (index: number, value: string) => {
+    setOptions((previous) => {
+      const next = [...previous];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const addOption = () => {
+    setOptions((previous) => {
+      if (previous.length >= MAX_VOTE_OPTIONS) {
+        return previous;
+      }
+      return [...previous, ''];
+    });
+  };
+
+  const removeOption = (index: number) => {
+    setOptions((previous) => {
+      if (previous.length <= 2) {
+        return previous;
+      }
+
+      const next = previous.filter((_, idx) => idx !== index);
+      setMaxSelections((oldValue) => Math.min(oldValue, next.length));
+      return next;
+    });
+  };
+
+  const createRound = (nextOptions: string[]) => {
+    const trimmedQuestion = question.trim();
+    const trimmedOptions = nextOptions
+      .map((option) => option.trim())
+      .filter(Boolean);
+
+    if (!trimmedQuestion) {
+      setErrorMessage('질문을 입력해주세요.');
+      return;
+    }
+
+    if (trimmedOptions.length < 2) {
+      setErrorMessage('선택지는 최소 2개가 필요합니다.');
+      return;
+    }
+
+    if (maxSelections > trimmedOptions.length) {
+      setErrorMessage('최대 선택 개수는 선택지 개수를 넘을 수 없습니다.');
+      return;
+    }
+
+    setErrorMessage('');
+    createVoteRoundMutation(
+      {
+        roomId,
+        question: trimmedQuestion,
+        maxSelections,
+        options: trimmedOptions,
+      },
+      {
+        onSuccess: () => {
+          setOptions(DEFAULT_OPTIONS);
+          setQuestion('');
+          setMaxSelections(1);
+          setRevoteOptionIds([]);
+          setIsCreatingRevote(false);
+          refetch();
+        },
+        onError: (error) => {
+          setErrorMessage(error.message);
+        },
+      },
+    );
+  };
+
+  const handleStartRound = () => {
+    if (!currentRound) return;
+
+    startVoteRoundMutation(
+      { roomId, roundId: currentRound.id },
+      {
+        onSuccess: () => refetch(),
+      },
+    );
+  };
+
+  const handleEndRound = () => {
+    if (!currentRound) return;
+
+    endVoteRoundMutation(
+      { roundId: currentRound.id },
+      {
+        onSuccess: () => refetch(),
+      },
+    );
+  };
+
+  const handleFinishRoom = () => {
+    finishVoteRoomMutation(
+      { roomId },
+      {
+        onSuccess: () => {
+          setActiveRoomId('');
+          refetch();
+        },
+      },
+    );
+  };
+
+  const buildRevote = () => {
+    if (!currentRound) return;
+    if (revoteOptionIds.length < 2) {
+      setErrorMessage('재투표는 최소 2개 선택지로 설정해주세요.');
+      return;
+    }
+
+    const revoteOptions = currentRound.options
+      .filter((option) => revoteOptionIds.includes(option.id))
+      .map((option) => option.label);
+
+    createRound(revoteOptions);
+  };
+
+  if (!snapshot) {
+    return (
+      <div className="w-full flex justify-center py-20">
+        <LoaderCircle className="size-5 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-3">
+        <Heading1 className="mb-0">{snapshot.room.title}</Heading1>
+        <div className="flex items-center gap-2">
+          <Badge variant="primary-outline">
+            연결 상태:{' '}
+            {connectionStatus === 'connected'
+              ? '정상'
+              : connectionStatus === 'reconnecting'
+                ? '재연결 중'
+                : '끊김'}
+          </Badge>
+          {connectionStatus !== 'connected' && (
+            <Button variant="gray-outline" size="sm" onClick={reconnect}>
+              <RefreshCw className="size-4 mr-1" />
+              다시 연결
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+        <Card className="xl:col-span-2">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span>진행 상태</span>
+              <Badge>
+                {snapshot.room.status === 'live'
+                  ? '투표 진행 중'
+                  : snapshot.room.status === 'ended'
+                    ? '투표 종료'
+                    : '투표 준비'}
+              </Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-2 text-sm text-text-subtitle">
+              <Users className="size-4" />
+              입장한 학생 수: {snapshot.joinedStudentCount}명
+            </div>
+
+            {currentRound ? (
+              <>
+                <div className="space-y-1">
+                  <Heading3 className="text-base">
+                    {currentRound.question}
+                  </Heading3>
+                  <div className="text-sm text-text-subtitle">
+                    최대 선택 가능 개수: {currentRound.maxSelections}개
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  {currentRound.options.map((option) => {
+                    const totalVotes = Math.max(currentRound.totalVotes, 1);
+                    const ratio = Math.round(
+                      (option.voteCount / totalVotes) * 100,
+                    );
+                    return (
+                      <div key={option.id} className="space-y-1">
+                        <div className="flex justify-between text-sm">
+                          <span>{option.label}</span>
+                          <span>{option.voteCount}표</span>
+                        </div>
+                        <div className="w-full h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                          <div
+                            className="h-full bg-primary transition-all"
+                            style={{ width: `${ratio}%` }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {currentRound.status === 'ready' && (
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={handleStartRound}
+                    isPending={isStarting}
+                  >
+                    투표 시작하기
+                  </Button>
+                )}
+
+                {currentRound.status === 'live' && (
+                  <Button
+                    variant="red"
+                    size="sm"
+                    onClick={handleEndRound}
+                    isPending={isEnding}
+                  >
+                    투표 종료하기
+                  </Button>
+                )}
+
+                {currentRound.status === 'ended' &&
+                  snapshot.room.status !== 'ended' && (
+                    <div className="space-y-3">
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          variant="gray-outline"
+                          size="sm"
+                          onClick={() => {
+                            setIsCreatingRevote((previous) => !previous);
+                            setErrorMessage('');
+                          }}
+                        >
+                          재투표 만들기
+                        </Button>
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          onClick={handleFinishRoom}
+                          isPending={isFinishing}
+                        >
+                          마무리하기
+                        </Button>
+                      </div>
+
+                      {isCreatingRevote && (
+                        <div className="rounded-md border dark:border-gray-700 p-3 space-y-3">
+                          <div className="text-sm text-text-subtitle">
+                            재투표에 포함할 선택지를 고르고 질문을 수정할 수
+                            있습니다.
+                          </div>
+                          <Textarea
+                            value={question}
+                            onChange={(event) =>
+                              setQuestion(event.target.value)
+                            }
+                            placeholder="재투표 질문"
+                          />
+                          <div className="space-y-2">
+                            {currentRound.options.map((option) => (
+                              <Label
+                                key={option.id}
+                                className="flex items-center gap-2 text-sm"
+                              >
+                                <Checkbox
+                                  checked={revoteOptionIds.includes(option.id)}
+                                  onCheckedChange={(checked) => {
+                                    setRevoteOptionIds((previous) => {
+                                      if (checked) {
+                                        return [...previous, option.id];
+                                      }
+                                      return previous.filter(
+                                        (id) => id !== option.id,
+                                      );
+                                    });
+                                  }}
+                                />
+                                {option.label}
+                              </Label>
+                            ))}
+                          </div>
+                          <Button
+                            variant="primary"
+                            size="sm"
+                            isPending={isRoundCreating}
+                            onClick={buildRevote}
+                          >
+                            재투표 라운드 생성
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+              </>
+            ) : (
+              <div className="text-sm text-text-subtitle">
+                아직 생성된 투표 라운드가 없습니다.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>학생 초대 QR</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col items-center gap-3">
+            <QRCodeCanvas
+              value={`${origin}/vote/student/${roomId}`}
+              size={220}
+            />
+            <div className="text-xs text-text-subtitle break-all">
+              {origin}/vote/student/{roomId}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {!currentRound && (
+        <Card>
+          <CardHeader>
+            <CardTitle>새 투표 만들기</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Textarea
+              placeholder="질문을 입력하세요."
+              value={question}
+              onChange={(event) => setQuestion(event.target.value)}
+            />
+            <div className="space-y-2">
+              {options.map((option, index) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <div key={`${index}-${option}`} className="flex gap-2">
+                  <Input
+                    value={option}
+                    onChange={(event) =>
+                      updateOptionValue(index, event.target.value)
+                    }
+                    placeholder={`선택지 ${index + 1}`}
+                  />
+                  <Button
+                    variant="gray-outline"
+                    size="sm"
+                    onClick={() => removeOption(index)}
+                    disabled={options.length <= 2}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                variant="gray-outline"
+                size="sm"
+                onClick={addOption}
+                disabled={options.length >= MAX_VOTE_OPTIONS}
+              >
+                <Plus className="size-4 mr-1" />
+                선택지 추가 ({options.length}/{MAX_VOTE_OPTIONS})
+              </Button>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="max-selections">학생 최대 선택 가능 개수</Label>
+              <Input
+                id="max-selections"
+                type="number"
+                min={1}
+                max={Math.max(
+                  1,
+                  options.filter((value) => value.trim()).length,
+                )}
+                value={maxSelections}
+                onChange={(event) => {
+                  const value = Number(event.target.value);
+                  if (!Number.isNaN(value)) {
+                    setMaxSelections(Math.max(1, value));
+                  }
+                }}
+              />
+            </div>
+
+            {errorMessage && <p className="text-sm text-red">{errorMessage}</p>}
+
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => createRound(options)}
+              isPending={isRoundCreating}
+            >
+              투표 라운드 만들기
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {snapshot.room.status === 'ended' && resultSourceRound && (
+        <Card>
+          <CardHeader>
+            <CardTitle>최종 결과 Top 3</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {top3.length === 0 ? (
+              <div className="text-sm text-text-subtitle">
+                집계된 결과가 없습니다.
+              </div>
+            ) : (
+              top3.map((option, index) => (
+                <div
+                  key={option.id}
+                  className="flex items-center justify-between border-b dark:border-gray-700 pb-2"
+                >
+                  <div className="font-medium text-text-title">
+                    {index + 1}위. {option.label}
+                  </div>
+                  <Badge>{option.voteCount}표</Badge>
+                </div>
+              ))
+            )}
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => {
+                setActiveRoomId('');
+                router.push('/vote');
+              }}
+            >
+              새로운 투표 만들기
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/apis/vote/use-create-vote-room.ts
+++ b/src/hooks/apis/vote/use-create-vote-room.ts
@@ -1,0 +1,8 @@
+import { createVoteRoom } from '@/apis/vote/vote';
+import { useMutation } from '@tanstack/react-query';
+
+export const useCreateVoteRoom = () => {
+  return useMutation({
+    mutationFn: createVoteRoom,
+  });
+};

--- a/src/hooks/apis/vote/use-create-vote-round.ts
+++ b/src/hooks/apis/vote/use-create-vote-round.ts
@@ -1,0 +1,8 @@
+import { createVoteRound } from '@/apis/vote/vote';
+import { useMutation } from '@tanstack/react-query';
+
+export const useCreateVoteRound = () => {
+  return useMutation({
+    mutationFn: createVoteRound,
+  });
+};

--- a/src/hooks/apis/vote/use-end-vote-round.ts
+++ b/src/hooks/apis/vote/use-end-vote-round.ts
@@ -1,0 +1,8 @@
+import { endVoteRound } from '@/apis/vote/vote';
+import { useMutation } from '@tanstack/react-query';
+
+export const useEndVoteRound = () => {
+  return useMutation({
+    mutationFn: endVoteRound,
+  });
+};

--- a/src/hooks/apis/vote/use-finish-vote-room.ts
+++ b/src/hooks/apis/vote/use-finish-vote-room.ts
@@ -1,0 +1,8 @@
+import { finishVoteRoom } from '@/apis/vote/vote';
+import { useMutation } from '@tanstack/react-query';
+
+export const useFinishVoteRoom = () => {
+  return useMutation({
+    mutationFn: finishVoteRoom,
+  });
+};

--- a/src/hooks/apis/vote/use-get-vote-snapshot.ts
+++ b/src/hooks/apis/vote/use-get-vote-snapshot.ts
@@ -1,0 +1,33 @@
+import {
+  getVoteStudentSnapshot,
+  getVoteTeacherSnapshot,
+} from '@/apis/vote/vote';
+import { useQueries, useQuery } from '@tanstack/react-query';
+
+export const useGetVoteTeacherSnapshot = (params: { roomId: string }) => {
+  return useQuery({
+    queryKey: ['vote-teacher-snapshot', params.roomId],
+    queryFn: () => getVoteTeacherSnapshot(params),
+    enabled: Boolean(params.roomId),
+  });
+};
+
+export const useGetVoteTeacherSnapshots = (roomIds: string[]) => {
+  return useQueries({
+    queries: roomIds.map((roomId) => ({
+      queryKey: ['vote-teacher-snapshot', roomId],
+      queryFn: () => getVoteTeacherSnapshot({ roomId }),
+    })),
+  });
+};
+
+export const useGetVoteStudentSnapshot = (params: {
+  roomId: string;
+  participantToken: string;
+}) => {
+  return useQuery({
+    queryKey: ['vote-student-snapshot', params.roomId, params.participantToken],
+    queryFn: () => getVoteStudentSnapshot(params),
+    enabled: Boolean(params.roomId && params.participantToken),
+  });
+};

--- a/src/hooks/apis/vote/use-join-vote-room-participant.ts
+++ b/src/hooks/apis/vote/use-join-vote-room-participant.ts
@@ -1,0 +1,8 @@
+import { joinVoteRoomParticipant } from '@/apis/vote/vote';
+import { useMutation } from '@tanstack/react-query';
+
+export const useJoinVoteRoomParticipant = () => {
+  return useMutation({
+    mutationFn: joinVoteRoomParticipant,
+  });
+};

--- a/src/hooks/apis/vote/use-start-vote-round.ts
+++ b/src/hooks/apis/vote/use-start-vote-round.ts
@@ -1,0 +1,8 @@
+import { startVoteRound } from '@/apis/vote/vote';
+import { useMutation } from '@tanstack/react-query';
+
+export const useStartVoteRound = () => {
+  return useMutation({
+    mutationFn: startVoteRound,
+  });
+};

--- a/src/hooks/apis/vote/use-submit-vote-ballot.ts
+++ b/src/hooks/apis/vote/use-submit-vote-ballot.ts
@@ -1,0 +1,8 @@
+import { submitVoteBallot } from '@/apis/vote/vote';
+import { useMutation } from '@tanstack/react-query';
+
+export const useSubmitVoteBallot = () => {
+  return useMutation({
+    mutationFn: submitVoteBallot,
+  });
+};

--- a/src/hooks/apis/vote/use-update-ready-vote-round.ts
+++ b/src/hooks/apis/vote/use-update-ready-vote-round.ts
@@ -1,0 +1,8 @@
+import { updateReadyVoteRound } from '@/apis/vote/vote';
+import { useMutation } from '@tanstack/react-query';
+
+export const useUpdateReadyVoteRound = () => {
+  return useMutation({
+    mutationFn: updateReadyVoteRound,
+  });
+};

--- a/src/hooks/apis/vote/use-vote-realtime.ts
+++ b/src/hooks/apis/vote/use-vote-realtime.ts
@@ -1,9 +1,32 @@
 import { getVoteTeacherSnapshot, VoteTeacherSnapshot } from '@/apis/vote/vote';
-import { supabase } from '@/utils/supabase';
+import { supabaseVote as supabase } from '@/utils/supabase';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 1000;
+type RealtimeRoomPayload = {
+  new: Record<string, unknown>;
+  old: Record<string, unknown>;
+};
+
+const isTargetRoomEvent = (
+  roomId: string,
+  payload: {
+    new: Record<string, unknown>;
+    old: Record<string, unknown>;
+  },
+  roomIdKey: 'roomId' | 'id',
+) => {
+  const changedRoomId = payload.new?.[roomIdKey];
+  const deletedRoomId = payload.old?.[roomIdKey];
+
+  // payload 제한으로 roomId가 없으면 안전하게 갱신해서 이벤트 누락을 방지합니다.
+  if (!changedRoomId && !deletedRoomId) {
+    return true;
+  }
+
+  return changedRoomId === roomId || deletedRoomId === roomId;
+};
 
 export function useVoteRealtime(
   roomId: string,
@@ -74,9 +97,13 @@ export function useVoteRealtime(
           'postgres_changes',
           { event: '*', schema: 'public', table: 'vote_ballots' },
           (payload) => {
-            const changedRoomId = (payload.new as { roomId?: string }).roomId;
-            const deletedRoomId = (payload.old as { roomId?: string }).roomId;
-            if (changedRoomId === roomId || deletedRoomId === roomId) {
+            if (
+              isTargetRoomEvent(
+                roomId,
+                payload as RealtimeRoomPayload,
+                'roomId',
+              )
+            ) {
               queueRefresh();
             }
           },
@@ -85,9 +112,13 @@ export function useVoteRealtime(
           'postgres_changes',
           { event: '*', schema: 'public', table: 'vote_participants' },
           (payload) => {
-            const changedRoomId = (payload.new as { roomId?: string }).roomId;
-            const deletedRoomId = (payload.old as { roomId?: string }).roomId;
-            if (changedRoomId === roomId || deletedRoomId === roomId) {
+            if (
+              isTargetRoomEvent(
+                roomId,
+                payload as RealtimeRoomPayload,
+                'roomId',
+              )
+            ) {
               queueRefresh();
             }
           },
@@ -96,9 +127,13 @@ export function useVoteRealtime(
           'postgres_changes',
           { event: '*', schema: 'public', table: 'vote_rounds' },
           (payload) => {
-            const changedRoomId = (payload.new as { roomId?: string }).roomId;
-            const deletedRoomId = (payload.old as { roomId?: string }).roomId;
-            if (changedRoomId === roomId || deletedRoomId === roomId) {
+            if (
+              isTargetRoomEvent(
+                roomId,
+                payload as RealtimeRoomPayload,
+                'roomId',
+              )
+            ) {
               queueRefresh();
             }
           },
@@ -107,9 +142,9 @@ export function useVoteRealtime(
           'postgres_changes',
           { event: '*', schema: 'public', table: 'vote_rooms' },
           (payload) => {
-            const changedRoomId = (payload.new as { id?: string }).id;
-            const deletedRoomId = (payload.old as { id?: string }).id;
-            if (changedRoomId === roomId || deletedRoomId === roomId) {
+            if (
+              isTargetRoomEvent(roomId, payload as RealtimeRoomPayload, 'id')
+            ) {
               queueRefresh();
             }
           },
@@ -157,4 +192,113 @@ export function useVoteRealtime(
   }, []);
 
   return [connectionStatus, reconnect] as const;
+}
+
+export function useVoteStudentRealtime(
+  roomId: string,
+  enabled: boolean,
+  refreshSnapshot: () => Promise<unknown>,
+) {
+  useEffect(() => {
+    if (!enabled || !roomId) return undefined;
+
+    let cancelled = false;
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    let fetching = false;
+    let initialLoadDone = false;
+    let pendingReload = false;
+
+    const cleanupChannel = () => {
+      if (channel) {
+        supabase.removeChannel(channel);
+        channel = null;
+      }
+    };
+
+    const refresh = async () => {
+      if (cancelled || fetching) return;
+      fetching = true;
+      try {
+        await refreshSnapshot();
+      } catch (error) {
+        if (!cancelled) {
+          console.error('학생 투표 스냅샷 갱신 실패:', error);
+        }
+      } finally {
+        fetching = false;
+      }
+    };
+
+    const queueRefresh = () => {
+      if (!initialLoadDone) {
+        pendingReload = true;
+        return;
+      }
+      refresh();
+    };
+
+    channel = supabase
+      .channel(`vote-student-room-${roomId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'vote_rooms' },
+        (payload) => {
+          if (isTargetRoomEvent(roomId, payload as RealtimeRoomPayload, 'id')) {
+            queueRefresh();
+          }
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'vote_rounds' },
+        (payload) => {
+          if (
+            isTargetRoomEvent(roomId, payload as RealtimeRoomPayload, 'roomId')
+          ) {
+            queueRefresh();
+          }
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'vote_participants' },
+        (payload) => {
+          if (
+            isTargetRoomEvent(roomId, payload as RealtimeRoomPayload, 'roomId')
+          ) {
+            queueRefresh();
+          }
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'vote_ballots' },
+        (payload) => {
+          if (
+            isTargetRoomEvent(roomId, payload as RealtimeRoomPayload, 'roomId')
+          ) {
+            queueRefresh();
+          }
+        },
+      )
+      .subscribe((status) => {
+        if (cancelled) return;
+
+        if (status === 'SUBSCRIBED') {
+          refresh().finally(() => {
+            if (cancelled) return;
+            initialLoadDone = true;
+            if (pendingReload) {
+              pendingReload = false;
+              refresh();
+            }
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      cleanupChannel();
+    };
+  }, [enabled, refreshSnapshot, roomId]);
 }

--- a/src/hooks/apis/vote/use-vote-realtime.ts
+++ b/src/hooks/apis/vote/use-vote-realtime.ts
@@ -1,0 +1,160 @@
+import { getVoteTeacherSnapshot, VoteTeacherSnapshot } from '@/apis/vote/vote';
+import { supabase } from '@/utils/supabase';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 1000;
+
+export function useVoteRealtime(
+  roomId: string,
+  handleSnapshot: (snapshot: VoteTeacherSnapshot) => void,
+) {
+  const [connectionStatus, setConnectionStatus] = useState<
+    'connected' | 'disconnected' | 'reconnecting'
+  >('disconnected');
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [reconnectKey, setReconnectKey] = useState(0);
+
+  useEffect(() => {
+    if (!roomId) return undefined;
+
+    let cancelled = false;
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    let initialLoadDone = false;
+    let pendingReload = false;
+    let fetching = false;
+
+    const cleanupChannel = () => {
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
+      }
+      if (channel) {
+        supabase.removeChannel(channel);
+        channel = null;
+      }
+    };
+
+    const refreshSnapshot = async () => {
+      if (cancelled || fetching) return;
+      fetching = true;
+      try {
+        const snapshot = await getVoteTeacherSnapshot({ roomId });
+        if (cancelled) return;
+        handleSnapshot(snapshot);
+      } catch (error) {
+        if (!cancelled) {
+          console.error('투표 스냅샷 갱신 실패:', error);
+        }
+      } finally {
+        fetching = false;
+      }
+    };
+
+    const queueRefresh = () => {
+      if (!initialLoadDone) {
+        pendingReload = true;
+        return;
+      }
+      refreshSnapshot();
+    };
+
+    const connect = () => {
+      cleanupChannel();
+      if (cancelled) return;
+
+      initialLoadDone = false;
+      pendingReload = false;
+      setConnectionStatus('reconnecting');
+
+      channel = supabase
+        .channel(`vote-room-${roomId}`)
+        .on(
+          'postgres_changes',
+          { event: '*', schema: 'public', table: 'vote_ballots' },
+          (payload) => {
+            const changedRoomId = (payload.new as { roomId?: string }).roomId;
+            const deletedRoomId = (payload.old as { roomId?: string }).roomId;
+            if (changedRoomId === roomId || deletedRoomId === roomId) {
+              queueRefresh();
+            }
+          },
+        )
+        .on(
+          'postgres_changes',
+          { event: '*', schema: 'public', table: 'vote_participants' },
+          (payload) => {
+            const changedRoomId = (payload.new as { roomId?: string }).roomId;
+            const deletedRoomId = (payload.old as { roomId?: string }).roomId;
+            if (changedRoomId === roomId || deletedRoomId === roomId) {
+              queueRefresh();
+            }
+          },
+        )
+        .on(
+          'postgres_changes',
+          { event: '*', schema: 'public', table: 'vote_rounds' },
+          (payload) => {
+            const changedRoomId = (payload.new as { roomId?: string }).roomId;
+            const deletedRoomId = (payload.old as { roomId?: string }).roomId;
+            if (changedRoomId === roomId || deletedRoomId === roomId) {
+              queueRefresh();
+            }
+          },
+        )
+        .on(
+          'postgres_changes',
+          { event: '*', schema: 'public', table: 'vote_rooms' },
+          (payload) => {
+            const changedRoomId = (payload.new as { id?: string }).id;
+            const deletedRoomId = (payload.old as { id?: string }).id;
+            if (changedRoomId === roomId || deletedRoomId === roomId) {
+              queueRefresh();
+            }
+          },
+        )
+        .subscribe(async (status) => {
+          if (cancelled) return;
+
+          if (status === 'SUBSCRIBED') {
+            retryCountRef.current = 0;
+            await refreshSnapshot();
+            if (cancelled) return;
+
+            initialLoadDone = true;
+            if (pendingReload) {
+              pendingReload = false;
+              await refreshSnapshot();
+            }
+            setConnectionStatus('connected');
+          } else if (status === 'CHANNEL_ERROR') {
+            if (retryCountRef.current < MAX_RETRIES) {
+              const delay = BASE_DELAY_MS * 2 ** retryCountRef.current;
+              retryCountRef.current += 1;
+              setConnectionStatus('reconnecting');
+              retryTimerRef.current = setTimeout(connect, delay);
+            } else {
+              setConnectionStatus('disconnected');
+            }
+          } else if (status === 'CLOSED') {
+            setConnectionStatus('disconnected');
+          }
+        });
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      cleanupChannel();
+    };
+  }, [roomId, reconnectKey, handleSnapshot]);
+
+  const reconnect = useCallback(() => {
+    retryCountRef.current = 0;
+    setReconnectKey((previous) => previous + 1);
+  }, []);
+
+  return [connectionStatus, reconnect] as const;
+}

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -16,7 +16,9 @@ type LocalStorageKey =
   | 'random-team-settings'
   | 'random-team-auto-run'
   | 'clock-memos'
-  | 'clock-memo';
+  | 'clock-memo'
+  | 'vote-room-ids'
+  | 'vote-active-room-id';
 
 /**
  * @description 페이지 새로 고침을 통해 상태가 유지되도록 로컬 저장소에 동기화합니다.

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -16,9 +16,7 @@ type LocalStorageKey =
   | 'random-team-settings'
   | 'random-team-auto-run'
   | 'clock-memos'
-  | 'clock-memo'
-  | 'vote-room-ids'
-  | 'vote-active-room-id';
+  | 'clock-memo';
 
 /**
  * @description 페이지 새로 고침을 통해 상태가 유지되도록 로컬 저장소에 동기화합니다.

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,6 +1,20 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const hasSupabaseEnv = Boolean(supabaseUrl && supabaseAnonKey);
+
+if (!hasSupabaseEnv) {
+  console.warn(
+    '[Supabase] NEXT_PUBLIC_SUPABASE_URL 또는 NEXT_PUBLIC_SUPABASE_ANON_KEY가 설정되지 않았습니다. Supabase 기능이 정상 동작하지 않을 수 있습니다.',
+  );
+}
+
+// NOTE: 환경변수가 없는 로컬 개발 환경에서도 앱 전체가 크래시나지 않도록 안전한 기본값을 사용합니다.
+// 실제 API 호출은 실패할 수 있으니 .env.local 설정이 필요합니다.
+export const supabase = createClient(
+  supabaseUrl ?? 'https://example.supabase.co',
+  supabaseAnonKey ??
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.placeholder.placeholder',
+);

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -2,8 +2,17 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseVoteUrl = process.env.NEXT_PUBLIC_SUPABASE_VOTE_URL;
+const supabaseVoteAnonKey = process.env.NEXT_PUBLIC_SUPABASE_VOTE_ANON_KEY;
 
 const hasSupabaseEnv = Boolean(supabaseUrl && supabaseAnonKey);
+const hasSupabaseVoteEnv = Boolean(supabaseVoteUrl && supabaseVoteAnonKey);
+
+if (!hasSupabaseVoteEnv) {
+  console.warn(
+    '[Supabase] NEXT_PUBLIC_SUPABASE_VOTE_URL 또는 NEXT_PUBLIC_SUPABASE_VOTE_ANON_KEY가 설정되지 않았습니다. Supabase 기능이 정상 동작하지 않을 수 있습니다.',
+  );
+}
 
 if (!hasSupabaseEnv) {
   console.warn(
@@ -16,5 +25,11 @@ if (!hasSupabaseEnv) {
 export const supabase = createClient(
   supabaseUrl ?? 'https://example.supabase.co',
   supabaseAnonKey ??
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.placeholder.placeholder',
+);
+
+export const supabaseVote = createClient(
+  supabaseVoteUrl ?? 'https://example.supabase.co',
+  supabaseVoteAnonKey ??
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.placeholder.placeholder',
 );


### PR DESCRIPTION
## 작업내용

이번 PR은 `feat/vote` 브랜치 기준으로 투표 기능 전반(교사/학생/랜딩/실시간/UUID 정규화/UI 개선)을 포함합니다.

- 투표 기본 기능 구축
  - 투표방/라운드/선택지/참여자/투표 API 및 훅 구성
  - 교사 화면에서 라운드 생성/시작/종료/재투표 흐름 정리
  - 학생 화면에서 선택 후 전송까지의 투표 참여 플로우 구성
- 실시간 동기화 강화
  - Supabase Realtime 기반으로 참여/시작/종료/결과 반영 흐름 개선
  - 교사-학생 화면 간 상태 전파 안정화
- 교사 화면 UX 개선
  - Ready 상태 라운드 수정 기능 추가
  - 종료된 투표의 결과 중심 UI 정리(불필요한 긴 정보 축소)
  - 결과 시각화 개선: Top3, 원형 그래프, 막대 그래프
  - QR 코드 액션 추가: 크게 보기 / 새 창 / URL 복사
- 학생 화면 UX 개선
  - UI 단순화 및 카드형 선택지 개선
  - 선택 제한 시 쉬운 에러 메시지 노출
  - 전송 버튼 가시성 강화
  - 이름 입력 제거 및 익명 처리 방향 정리
- 라우팅/호환성 보완
  - 구형 `vote-room-...` 형태 roomId를 UUID로 정규화하여 접근 가능하도록 처리
- 랜딩 페이지 개선
  - 투표 기능 안내 문구 및 빠른 생성 UX 개선
  - “종료된 투표는 다시 시작할 수 없고 새로 만들어야 함” 안내 반영

## 리뷰노트

- 변경 범위가 크므로 커밋 단위 리뷰를 권장드립니다.
  - 예: `교사 화면 개선` / `원, 막대 그래프 작업` / `학생 측 ui 개선` / `uuid 만 적용`
- 이번 PR은 기능 추가와 UX 리팩터링이 함께 포함되어 있습니다.
- 확인 포인트
  - 교사/학생 실시간 동기화
  - 종료 후 결과 조회 흐름
  - 학생 선택/전송 동작(`maxSelections` 제약)
  - 구형 roomId 링크 진입

## 스크린샷

- [ ] 투표 랜딩 페이지 개선 화면
- [ ] 교사 화면(Ready 수정/시작/종료) 화면
- [ ] 결과 화면(Top3/원형/막대) 화면
- [ ] QR 코드 크게 보기/새 창/URL 복사 화면
- [ ] 학생 화면(선택/에러 메시지/전송 버튼) 화면

### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [ ] 나는 변경 사항에 대해 크롬에서 테스트를 했다.