### PR TITLE
feat: 랜덤 모둠 뽑기 학생 편집 기능 추가

### DIFF
--- a/src/containers/random-team/random-team-container.tsx
+++ b/src/containers/random-team/random-team-container.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
-import { Shuffle, Settings } from 'lucide-react';
+import { Shuffle, Settings, UserPen, X, Plus } from 'lucide-react';
 
 import { Button } from '@/components/button';
 import { Card } from '@/components/card';
@@ -14,10 +14,15 @@ import { useRandomTeamSettings } from './hooks/useRandomTeamStorage';
 export default function RandomTeamContainer() {
   const [mounted, setMounted] = useState(false);
 
-  const [settings] = useRandomTeamSettings();
+  const [settings, setRandomTeamSettings] = useRandomTeamSettings();
 
   const [showResult, setShowResult] = useState(false);
   const assignRef = useRef<() => void>();
+
+  // 학생 편집 모달 관련 상태
+  const [showEditStudents, setShowEditStudents] = useState(false);
+  const [editStudentNames, setEditStudentNames] = useState<string[]>([]);
+  const [editStudentInput, setEditStudentInput] = useState('');
 
   useEffect(() => {
     setMounted(true);
@@ -39,22 +44,86 @@ export default function RandomTeamContainer() {
 
   const isReady = hasSettings && typeof settings.teamCount === 'number';
 
+  const openEditStudents = () => {
+    if (!settings?.students) return;
+    setEditStudentNames([...settings.students]);
+    setEditStudentInput('');
+    setShowEditStudents(true);
+  };
+
+  const handleEditAddStudent = () => {
+    const name = editStudentInput.trim();
+    if (name && !editStudentNames.includes(name)) {
+      setEditStudentNames((prev) => [...prev, name]);
+      setEditStudentInput('');
+    }
+  };
+
+  const handleEditAddBulk = () => {
+    const names = editStudentInput
+      .split(/[,\n]/)
+      .map((name) => name.trim())
+      .filter((name) => name && !editStudentNames.includes(name));
+
+    if (names.length > 0) {
+      setEditStudentNames((prev) => [...prev, ...names]);
+      setEditStudentInput('');
+    }
+  };
+
+  const handleEditRemoveStudent = (nameToRemove: string) => {
+    setEditStudentNames((prev) => prev.filter((name) => name !== nameToRemove));
+  };
+
+  const handleEditComplete = () => {
+    if (!settings) return;
+
+    const updatedStudents = editStudentNames;
+    const updatedPreAssignments = settings.preAssignments.filter((item) =>
+      updatedStudents.includes(item.student),
+    );
+
+    setRandomTeamSettings({
+      ...settings,
+      students: updatedStudents,
+      preAssignments: updatedPreAssignments,
+    });
+
+    setShowEditStudents(false);
+    setShowResult(false);
+  };
+
   return (
     <div className="p-6 max-w-6xl mx-auto flex flex-col gap-6">
       <Card className="p-5 flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <Heading1 className="text-xl font-bold">랜덤 모둠 구성</Heading1>
 
-          <Link href="/random-team/settings/1">
-            <Button
-              variant="primary"
-              size="sm"
-              className="flex items-center gap-2 px-4 hover:shadow-md transition-all"
-            >
-              <Settings className="w-4 h-4" />
-              {hasSettings ? '수정하기' : '시작하기'}
-            </Button>
-          </Link>
+          <div className="flex items-center gap-2">
+            {/* 🎨 발표 도우미 스타일과 동일하게 변경된 [학생 편집] 버튼 */}
+            {isReady && (
+              <Button
+                onClick={openEditStudents}
+                variant="primary"
+                size="sm"
+                className="flex items-center gap-2 px-4 hover:shadow-md transition-all"
+              >
+                <UserPen className="h-4 w-4" />
+                학생 편집
+              </Button>
+            )}
+
+            <Link href="/random-team/settings/1">
+              <Button
+                variant="primary"
+                size="sm"
+                className="flex items-center gap-2 px-4 hover:shadow-md transition-all"
+              >
+                <Settings className="w-4 h-4" />
+                {hasSettings ? '수정하기' : '시작하기'}
+              </Button>
+            </Link>
+          </div>
         </div>
 
         {isReady && (
@@ -87,6 +156,112 @@ export default function RandomTeamContainer() {
             assignRef={assignRef}
             showFixedMark={settings.showFixedMark}
           />
+        </div>
+      )}
+
+      {/* ================= 🎨 발표 도우미 테마로 통일된 학생 편집 모달 UI ================= */}
+      {showEditStudents && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/30 backdrop-blur-sm"
+          onClick={() => setShowEditStudents(false)}
+        >
+          <div
+            className="mx-4 max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-lg font-bold text-foreground">학생 편집</h3>
+              <button
+                onClick={() => setShowEditStudents(false)}
+                className="rounded-full p-1 transition-colors hover:bg-secondary"
+              >
+                <X className="h-5 w-5 text-muted-foreground" />
+              </button>
+            </div>
+
+            <p className="mb-4 text-sm text-muted-foreground">
+              학생을 추가하거나 삭제할 수 있어요. 쉼표(,)로 여러 명을 한번에
+              추가할 수 있어요.
+            </p>
+
+            {/* 입력 영역 */}
+            <div className="mb-3 flex gap-2">
+              <input
+                type="text"
+                value={editStudentInput}
+                onChange={(event) => setEditStudentInput(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    if (editStudentInput.includes(',')) {
+                      handleEditAddBulk();
+                    } else {
+                      handleEditAddStudent();
+                    }
+                  }
+                }}
+                placeholder="학생 이름"
+                className="flex-1 rounded-xl border border-input bg-background px-4 py-2.5 text-sm text-foreground outline-none focus:ring-2 focus:ring-ring"
+              />
+              <Button
+                onClick={() => {
+                  if (editStudentInput.includes(',')) {
+                    handleEditAddBulk();
+                  } else {
+                    handleEditAddStudent();
+                  }
+                }}
+                variant="primary"
+                className="rounded-xl px-4 py-2.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+
+            {/* 학생 명단 태그 리스트 */}
+            {editStudentNames.length > 0 && (
+              <div className="mb-4 max-h-[240px] overflow-y-auto">
+                <div className="flex flex-wrap gap-2">
+                  {editStudentNames.map((name) => (
+                    <span
+                      key={name}
+                      className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1.5 text-sm text-primary"
+                    >
+                      {name}
+                      <button
+                        onClick={() => handleEditRemoveStudent(name)}
+                        className="transition-colors hover:text-destructive"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  총 {editStudentNames.length}명
+                </p>
+              </div>
+            )}
+
+            {/* 하단 제어 버튼 */}
+            <div className="flex gap-2">
+              <Button
+                onClick={() => setShowEditStudents(false)}
+                variant="primary"
+                className="px-6 py-3 font-medium text-primary-foreground hover:opacity-90"
+              >
+                취소
+              </Button>
+              <Button
+                onClick={handleEditComplete}
+                disabled={editStudentNames.length === 0}
+                variant="primary"
+                className="flex-1 py-3 font-medium text-primary-foreground hover:opacity-90"
+              >
+                저장 ({editStudentNames.length}명)
+              </Button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/containers/random-team/random-team-container.tsx
+++ b/src/containers/random-team/random-team-container.tsx
@@ -100,7 +100,6 @@ export default function RandomTeamContainer() {
           <Heading1 className="text-xl font-bold">랜덤 모둠 구성</Heading1>
 
           <div className="flex items-center gap-2">
-            {/* 🎨 발표 도우미 스타일과 동일하게 변경된 [학생 편집] 버튼 */}
             {isReady && (
               <Button
                 onClick={openEditStudents}
@@ -159,7 +158,6 @@ export default function RandomTeamContainer() {
         </div>
       )}
 
-      {/* ================= 🎨 발표 도우미 테마로 통일된 학생 편집 모달 UI ================= */}
       {showEditStudents && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/30 backdrop-blur-sm"


### PR DESCRIPTION
## 작업내용

- [ ] 랜덤 모둠 뽑기에 학생 즉시 편집 기능 추가(결석생 반영 용도)
- [ ] 학생 즉시 삭제, 추가 가능
- [ ] 학생 목록에도 반영하여 퍼널식 셋팅에서도 볼 수 있음

<!---
어떤 작업을 했는지 설명을 작성해 주세요.
리뷰어가 PR 내용만으로 어떤 변경이 있는지 모두 알 수 있도록 작성해 주세요.
-->

## 리뷰노트

- [ ] 원래는 학생을 한명씩 삭제하거나 추가하는 게 불가능하여 명단 자체를 수정해야 했으나 한명씩 삭제/추가 기능 
- [ ] 삭제/추가된 학생 명단을 퍼널식 셋팅에도 반영

<!---
리뷰어가 PR를 리뷰하기 앞서 미리 알려드리고 싶은 내용을 작성해주세요.
-->

## 스크린샷

<img width="1347" height="619" alt="image" src="https://github.com/user-attachments/assets/f2772e8c-d228-40da-9e97-c0954de80cd5" />
<img width="1298" height="763" alt="image" src="https://github.com/user-attachments/assets/e90f79c6-66cd-4cd5-9ac7-4fe24f5d68e9" />

<!---
코드 이외에 화면의 UI/UX를 스크린샷으로 남겨주세요.
-->

### 개발 체크리스트

<!--- 아래 목록을 확인하시고 `x` 표시를 해주세요. -->

- [ ] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [ ] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
