### PR TITLE
Fix/music request security

### DIFF
--- a/src/apis/music-request/musicRequest.ts
+++ b/src/apis/music-request/musicRequest.ts
@@ -1,5 +1,8 @@
 import { supabase } from '@/utils/supabase';
 
+// DB의 musics_student_name_length 제약과 동일한 값
+export const MAX_STUDENT_NAME_LENGTH = 20;
+
 // ─── secret_token 유틸 (방 개설자 인증용) ───
 
 const SECRET_TOKEN_PREFIX = 'music-room-secret-';
@@ -119,7 +122,7 @@ export const createMusicRequestMusic = async (params: {
       musicId: params.musicId,
       title: params.title,
       roomId: params.roomId,
-      studentName: params.student,
+      studentName: params.student.trim().slice(0, MAX_STUDENT_NAME_LENGTH),
       timeStamp: new Date().toISOString(),
     })
     .select()

--- a/src/containers/music-request/music-request-student/music-request-student-main/create-name-page/create-name-page.tsx
+++ b/src/containers/music-request/music-request-student/music-request-student-main/create-name-page/create-name-page.tsx
@@ -11,6 +11,7 @@ import { useForm } from 'react-hook-form';
 import { Button } from '@/components/button';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { MAX_STUDENT_NAME_LENGTH } from '@/apis/music-request/musicRequest';
 import {
   useMusicRequestStudentAction,
   useMusicRequestStudentState,
@@ -18,13 +19,18 @@ import {
 
 const STUDENT_NAME_ERROR_MESSAGE = {
   EMPTY_INPUT: '이름을 입력해 주세요.',
+  MAX_LENGTH: `이름은 ${MAX_STUDENT_NAME_LENGTH}자 이내로 입력해 주세요.`,
   API_ERROR: '방입장에 실패 했어요. 다시 시도해주세요.',
 } as const;
 
 const formSchema = z.object({
   studentNameInput: z
     .string()
-    .nonempty({ message: STUDENT_NAME_ERROR_MESSAGE.EMPTY_INPUT }),
+    .trim()
+    .nonempty({ message: STUDENT_NAME_ERROR_MESSAGE.EMPTY_INPUT })
+    .max(MAX_STUDENT_NAME_LENGTH, {
+      message: STUDENT_NAME_ERROR_MESSAGE.MAX_LENGTH,
+    }),
 });
 
 type Props = {
@@ -62,8 +68,8 @@ export default function CreateNamePage({ roomId }: Props) {
                   Cookies.remove(roomId);
                   settingStudentName('');
                 }
-              : form.handleSubmit(() =>
-                  handleStudentName(form.getValues('studentNameInput')),
+              : form.handleSubmit((values) =>
+                  handleStudentName(values.studentNameInput),
                 )
           }
           className="space-b-4"
@@ -78,6 +84,7 @@ export default function CreateNamePage({ roomId }: Props) {
                     <Input
                       type="text"
                       {...field}
+                      maxLength={MAX_STUDENT_NAME_LENGTH}
                       placeholder={studentName || '이름을 입력해주세요.'}
                       className={`${studentName ? 'placeholder:text-text-title' : ''}`}
                       disabled={!!studentName}

--- a/src/hooks/apis/music-request/use-music-realtime.ts
+++ b/src/hooks/apis/music-request/use-music-realtime.ts
@@ -91,7 +91,12 @@ export function useMusicRealtime(
         .channel(`room-${roomId}`)
         .on(
           'postgres_changes',
-          { event: 'INSERT', schema: 'public', table: 'musics' },
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'musics',
+            filter: `roomId=eq.${roomId}`,
+          },
           (payload) => {
             if (cancelled) return;
             const newMusic = payload.new as YoutubeVideo & {
@@ -108,11 +113,16 @@ export function useMusicRealtime(
         )
         .on(
           'postgres_changes',
-          { event: 'DELETE', schema: 'public', table: 'musics' },
+          {
+            event: 'DELETE',
+            schema: 'public',
+            table: 'musics',
+            filter: `roomId=eq.${roomId}`,
+          },
           (payload) => {
             if (cancelled) return;
-            // DELETE의 payload.old는 REPLICA IDENTITY 설정에 따라 PK만 올 수 있으므로
-            // old.roomId 대신 knownIdsRef로 이 방의 음악인지 판별
+            // musics는 REPLICA IDENTITY FULL이라 서버에서 이 방의 이벤트만 걸러 보낸다.
+            // payload.old의 컬럼 구성에 의존하지 않도록 knownIdsRef 판별은 그대로 둔다.
             const old = payload.old as { id: number };
 
             if (!initialLoadDone) {

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "TeacherCan"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files, directories, or glob patterns that describe your database.
+# Supports paths relative to supabase directory: "./schemas/*.sql", "./database".
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260804232813_remote_schema.sql
+++ b/supabase/migrations/20260804232813_remote_schema.sql
@@ -1,0 +1,205 @@
+-- Migration unit 1: schema_changes
+-- Transaction mode: transactional
+-- Boundary reason: default
+
+SET check_function_bodies = false;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT DELETE, INSERT, SELECT, UPDATE ON TABLES TO anon;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT, USAGE ON SEQUENCES TO anon;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON ROUTINES TO anon;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT DELETE, INSERT, SELECT, UPDATE ON TABLES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT, USAGE ON SEQUENCES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON ROUTINES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT DELETE, INSERT, SELECT, UPDATE ON TABLES TO service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT, USAGE ON SEQUENCES TO service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON ROUTINES TO service_role;
+
+CREATE FUNCTION public.create_room (
+  p_room_title   text,
+  p_secret_token uuid
+)
+  RETURNS uuid
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+  AS $function$
+  DECLARE
+    v_room_id UUID := gen_random_uuid();
+  BEGIN
+    INSERT INTO rooms (id, "roomTitle", "connectedAt")
+    VALUES (v_room_id, p_room_title, now());
+
+    INSERT INTO room_secrets (room_id, secret_token)
+    VALUES (v_room_id, p_secret_token);
+
+    RETURN v_room_id;
+  END;
+  $function$;
+
+GRANT ALL ON FUNCTION public.create_room(text, uuid) TO anon;
+
+GRANT ALL ON FUNCTION public.create_room(text, uuid) TO authenticated;
+
+GRANT ALL ON FUNCTION public.create_room(text, uuid) TO service_role;
+
+CREATE FUNCTION public.delete_music (
+  p_room_id      uuid,
+  p_music_id     text,
+  p_secret_token uuid
+)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+  AS $function$
+BEGIN
+  -- 1) 방을 최초 생성했던 진짜 주인인지 토큰 검증
+  IF NOT EXISTS (
+    SELECT 1
+    FROM room_secrets
+    WHERE room_id = p_room_id
+      AND secret_token = p_secret_token
+  ) THEN
+    -- 토큰이 틀리면 에러를 터트리고 중단 (해킹 방어)
+    RAISE EXCEPTION 'Unauthorized: 삭제 권한이 없는 가짜 열쇠입니다.';
+  END IF;
+
+  -- 2) 토큰 검증에 성공했다면, 방해받지 않고 안전하게 음악 삭제!
+  DELETE FROM musics
+  WHERE "roomId" = p_room_id
+    AND "musicId" = p_music_id;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.delete_music(uuid, text, uuid) TO anon;
+
+GRANT ALL ON FUNCTION public.delete_music(uuid, text, uuid) TO authenticated;
+
+GRANT ALL ON FUNCTION public.delete_music(uuid, text, uuid) TO service_role;
+
+CREATE TABLE public.musics (
+  id            bigint                   GENERATED ALWAYS AS IDENTITY NOT NULL,
+  "musicId"     text                     NOT NULL,
+  title         text                     NOT NULL,
+  "roomId"      uuid                     NOT NULL,
+  "studentName" text,
+  "timeStamp"   timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER PUBLICATION supabase_realtime ADD TABLE public.musics;
+
+ALTER TABLE public.musics
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.musics
+  REPLICA IDENTITY FULL;
+
+ALTER TABLE public.musics
+  ADD CONSTRAINT musics_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.musics
+  ADD CONSTRAINT musics_room_music_unique UNIQUE ("roomId", "musicId");
+
+GRANT ALL ON public.musics TO anon;
+
+GRANT ALL ON public.musics TO authenticated;
+
+GRANT ALL ON public.musics TO service_role;
+
+CREATE POLICY musics_delete ON public.musics
+  FOR DELETE
+  USING (false);
+
+CREATE POLICY musics_insert ON public.musics
+  FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY musics_select ON public.musics
+  FOR SELECT
+  USING (true);
+
+CREATE POLICY musics_update ON public.musics
+  FOR UPDATE
+  USING (false);
+
+CREATE TABLE public.room_secrets (
+  id           bigint                   GENERATED ALWAYS AS IDENTITY NOT NULL,
+  room_id      uuid                     NOT NULL,
+  secret_token uuid                     DEFAULT gen_random_uuid() NOT NULL,
+  created_at   timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE public.room_secrets
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.room_secrets
+  ADD CONSTRAINT room_secrets_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.room_secrets
+  ADD CONSTRAINT room_secrets_room_id_key UNIQUE (room_id);
+
+GRANT ALL ON public.room_secrets TO anon;
+
+GRANT ALL ON public.room_secrets TO authenticated;
+
+GRANT ALL ON public.room_secrets TO service_role;
+
+CREATE POLICY room_secrets_delete ON public.room_secrets
+  FOR DELETE
+  USING (false);
+
+CREATE POLICY room_secrets_insert ON public.room_secrets
+  FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY room_secrets_select ON public.room_secrets
+  FOR SELECT
+  USING (false);
+
+CREATE POLICY room_secrets_update ON public.room_secrets
+  FOR UPDATE
+  USING (false);
+
+CREATE TABLE public.rooms (
+  id            uuid                     DEFAULT gen_random_uuid() NOT NULL,
+  "roomTitle"   text                     NOT NULL,
+  "connectedAt" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE public.rooms
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.rooms
+  ADD CONSTRAINT rooms_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.musics
+  ADD CONSTRAINT "musics_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES public.rooms(id) ON DELETE CASCADE;
+
+ALTER TABLE public.room_secrets
+  ADD CONSTRAINT room_secrets_room_id_fkey FOREIGN KEY (room_id) REFERENCES public.rooms(id) ON DELETE CASCADE;
+
+GRANT ALL ON public.rooms TO anon;
+
+GRANT ALL ON public.rooms TO authenticated;
+
+GRANT ALL ON public.rooms TO service_role;
+
+CREATE POLICY rooms_delete ON public.rooms
+  FOR DELETE
+  USING (false);
+
+CREATE POLICY rooms_insert ON public.rooms
+  FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY rooms_select ON public.rooms
+  FOR SELECT
+  USING (true);

--- a/supabase/migrations/20260805014806_drop_duplicate_unique.sql
+++ b/supabase/migrations/20260805014806_drop_duplicate_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.musics DROP CONSTRAINT IF EXISTS "musics_roomId_musicId_key";

--- a/supabase/migrations/20260805020705_harden_music_request_rls.sql
+++ b/supabase/migrations/20260805020705_harden_music_request_rls.sql
@@ -1,0 +1,21 @@
+-- 음악신청 RLS 정리
+--
+-- create_room, delete_music 은 SECURITY DEFINER 로 RLS 를 우회한다.
+-- 따라서 anon 에게 열려 있던 아래 INSERT 정책들은 실제로 아무도 쓰지 않는 통로다.
+-- 열어두면 room_secrets 에 임의의 토큰을 심으려는 시도의 진입점이 되므로 닫는다.
+-- (현재는 room_secrets.room_id 의 UNIQUE 제약이 우연히 막고 있을 뿐이다.)
+
+ALTER POLICY rooms_insert ON public.rooms
+  WITH CHECK (false);
+
+ALTER POLICY room_secrets_insert ON public.room_secrets
+  WITH CHECK (false);
+
+-- rooms 만 UPDATE 정책이 없어 암묵적으로 거부되고 있었다.
+-- 동작은 같지만 다른 테이블과 동일하게 의도를 명시한다.
+
+DROP POLICY IF EXISTS rooms_update ON public.rooms;
+
+CREATE POLICY rooms_update ON public.rooms
+  FOR UPDATE
+  USING (false);

--- a/supabase/migrations/20260805030937_limit_music_request_input.sql
+++ b/supabase/migrations/20260805030937_limit_music_request_input.sql
@@ -1,0 +1,24 @@
+-- 1) 기존 위반 데이터 정리
+UPDATE public.musics
+SET "studentName" = left("studentName", 17) || '...'
+WHERE char_length("studentName") > 20;
+
+UPDATE public.musics
+SET "studentName" = '익명'
+WHERE btrim("studentName") = '';
+
+-- 2) 입력 제약 추가
+ALTER TABLE public.musics ALTER COLUMN "studentName" SET NOT NULL;
+
+ALTER TABLE public.musics
+  ADD CONSTRAINT musics_student_name_length CHECK (char_length("studentName") <= 20);
+
+ALTER TABLE public.musics
+  ADD CONSTRAINT musics_student_name_trimmed
+  CHECK ("studentName" = btrim("studentName") AND "studentName" <> '');
+
+ALTER TABLE public.musics
+  ADD CONSTRAINT musics_title_length CHECK (char_length(title) <= 200);
+
+ALTER TABLE public.musics
+  ADD CONSTRAINT musics_music_id_format CHECK ("musicId" ~ '^[A-Za-z0-9_-]{11}$');


### PR DESCRIPTION
## 작업내용

음악신청 기능의 DB 접근 제어와 입력 검증 강화. Supabase 스키마를 마이그레이션으로 관리하도록 전환.

### 1. Supabase 스키마 마이그레이션 도입

기존에는 테이블·RLS 정책·함수가 모두 Supabase 대시보드에만 존재해 변경 이력이 남지 않고 코드 리뷰 대상도 아님. `supabase db pull`로 현재 상태를 기준선 마이그레이션으로 가져와 커밋함.

- `20260804232813_remote_schema.sql` — 기존 DB 상태 기준선 (신규 변경 아님)
- 가져온 파일에서 `db pull` 부산물(`DROP EXTENSION`, `CREATE ROLE`) 제거

### 2. 중복 제약 제거

`musics` 테이블에 `(roomId, musicId)` UNIQUE 제약이 이름만 다르게 **두 번** 걸려 있어 INSERT마다 동일한 인덱스를 두 번 갱신하고 있어, 하나를 제거.

- `20260805014806_drop_duplicate_unique.sql`

### 3. 사용되지 않던 INSERT 정책 차단

`create_room`이 `SECURITY DEFINER`로 RLS를 우회하므로, anon에게 열려 있던 `rooms`·`room_secrets`의 INSERT 정책은 실제로 아무도 사용하지 않는 통로였음. 열어둘 경우 `room_secrets`에 임의 토큰을 심어 삭제 권한을 탈취하려는 시도의 진입점이 됨. (현재는 `room_secrets.room_id`의 UNIQUE 제약이 우연히 막고 있는 상태)

- `rooms_insert`, `room_secrets_insert` → `WITH CHECK (false)`
- `rooms`만 UPDATE 정책이 없어 암묵적으로 거부되던 것을 다른 테이블과 동일하게 명시
- `20260805020705_harden_music_request_rls.sql`

### 4. 실시간 구독을 방 단위로 필터링

교사 화면이 `musics` 테이블 **전체**를 구독하고 다른 방의 이벤트를 브라우저에서 걸러내고 있었음. 버리기 전에 이미 수신하므로, 접속 중인 모든 교사 화면에 다른 교실의 신청곡과 학생 이름이 전달되고 있었음.

- `use-music-realtime.ts`의 INSERT·DELETE 구독에 `filter: roomId=eq.${roomId}` 추가
- `musics`가 `REPLICA IDENTITY FULL`이라 DELETE 이벤트에도 필터가 정상 동작
- 클라이언트 측 `roomId` 비교와 `knownIdsRef` 판별은 안전망으로 유지

### 5. 입력 제약 추가

`musicId`·`title`·`studentName`에 아무 문자열이나 저장할 수 있었음. 실제로 이름 칸에 유튜브 주소를 붙여넣거나 장난으로 긴 문자열을 넣은 데이터가 남아 있었음.

**DB (`20260805030937_limit_music_request_input.sql`)** (미적용 — 배포 후 push 예정)

- 기존 위반 데이터 정리: 20자 초과 이름은 `17자 + ...`으로, 공백뿐인 이름은 `익명`으로 변경
- `studentName` → `NOT NULL`
- `CHECK` 추가: `studentName` 20자 이내 / 앞뒤 공백 없음 / `title` 200자 이내 / `musicId`는 유튜브 영상 ID 형식(`^[A-Za-z0-9_-]{11}$`)

**프론트**

- 이름 입력에 `zod`의 `.trim()`, `.max(20)` 추가 — 공백만 입력하는 경우도 차단
- `<Input maxLength={20}>` 전달 — 붙여넣기까지 차단되어 주소 입력이 원천 방지
- `handleSubmit`이 넘겨주는 검증된 값을 사용하도록 변경. 기존에는 `getValues()`로 원본을 읽어 `.trim()` 결과가 버려지는 구조였음
- `createMusicRequestMusic`에서 API 경계 정규화. DB 제약이 거부형이라 다듬지 않고 보내면 Postgres 원문 에러가 사용자에게 노출됨

## 리뷰노트

**마이그레이션 적용 상태가 파일마다 다름**

| 파일 | 원격 DB 적용 |
|---|---|
| `20260804232813_remote_schema.sql` | 완료 (기준선) |
| `20260805014806_drop_duplicate_unique.sql` | 완료 |
| `20260805020705_harden_music_request_rls.sql` | 완료 |
| `20260805030937_limit_music_request_input.sql` | **미적용 — 배포 후 push 예정** |

마지막 마이그레이션의 `CHECK` 제약은 **거부형**. 현재 운영 프론트에는 길이·공백 검증이 없어서, 배포 전에 `db push`하면 학생이 곡 신청 단계에서 Postgres 원문 에러를 보게 됨. 따라서 **머지 → 배포 완료 확인 → `db push`** 순서로 진행. 새 프론트는 제약이 없는 현재 DB에서도 정상 동작하므로 이 순서는 안전.

**검증 완료 항목**

- 방 생성 / 곡 신청 / 실시간 반영 / 곡 삭제 정상
- 20자 초과 입력·붙여넣기 차단, 공백만 입력 시 에러 메시지 노출 확인
- 정책 적용 상태를 `pg_policies`로 확인

**후속 과제 (이번 범위 아님)**

- `rooms_select`·`musics_select`가 여전히 전체 공개라, anon 키로 직접 조회하면 모든 방과 학생 이름을 볼 수 있음. 실시간 기능이 SELECT 정책에 의존하기 때문에 방 단위 JWT 발급 같은 별도 설계가 필요해 후속 과제로 분리.

## 스크린샷

UI 변경은 학생 이름 입력칸의 길이 제한과 에러 메시지뿐이라 별도 첨부는 생략.

### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.