### PR TITLE
Feat/music request admin

### DIFF
--- a/src/apis/music-request/musicRequest.ts
+++ b/src/apis/music-request/musicRequest.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/utils/supabase';
 
-// DB의 musics_student_name_length 제약과 동일한 값
+// 입력 UI 에서 쓰는 길이 제한.
+// 실제 강제는 add_music 함수와 musics_student_name_length 제약이 하므로 셋을 함께 맞춰야 한다.
 export const MAX_STUDENT_NAME_LENGTH = 20;
 
 // ─── secret_token 유틸 (방 개설자 인증용) ───
@@ -39,14 +40,6 @@ export type GetMusicRequestRoomResponse = {
 
 type CreateMusicRequestRoomResponse = { roomId: string };
 type GetMusicRequestRoomTitleResponse = { roomTitle: string };
-type CreateMusicRequestMusicResponse = {
-  musicId: string;
-  roomId: string;
-  studentId: number;
-  title: string;
-  id: number;
-  timeStamp: string;
-};
 
 // ─── API 함수들 (Supabase 직접 호출) ───
 
@@ -82,57 +75,38 @@ export const createMusicRequestRoom = async (params: {
 export const getMusicRequestRoomTitle = async (params: {
   roomId: string;
 }): Promise<GetMusicRequestRoomTitleResponse> => {
-  const { data, error } = await supabase
-    .from('rooms')
-    .select('roomTitle')
-    .eq('id', params.roomId)
-    .single();
+  const { data, error } = await supabase.rpc('get_room_title', {
+    p_room_id: params.roomId,
+  });
 
   if (error) {
     throw new Error(error.message);
   }
 
-  return { roomTitle: data.roomTitle };
+  return { roomTitle: data as string };
 };
 
 /**
- * 음악 추가 — musics 테이블에 INSERT (중복 체크 포함)
+ * 음악 추가 — RPC 함수(add_music)를 통해 서버 측에서 검증 후 INSERT
+ * 방 존재 여부 / 유튜브 ID 형식 / 이름 다듬기 / 중복 / 방 곡수 상한을 함수가 처리하고,
+ * 위반 시 사용자에게 보여줄 문구를 그대로 에러 메시지로 던진다.
  */
 export const createMusicRequestMusic = async (params: {
   roomId: string;
   student: string;
   musicId: string;
   title: string;
-}): Promise<CreateMusicRequestMusicResponse> => {
-  // 중복 체크
-  const { data: existing } = await supabase
-    .from('musics')
-    .select('id')
-    .eq('roomId', params.roomId)
-    .eq('musicId', params.musicId)
-    .maybeSingle();
-
-  if (existing) {
-    throw new Error('이미 신청된 음악입니다.');
-  }
-
-  const { data, error } = await supabase
-    .from('musics')
-    .insert({
-      musicId: params.musicId,
-      title: params.title,
-      roomId: params.roomId,
-      studentName: params.student.trim().slice(0, MAX_STUDENT_NAME_LENGTH),
-      timeStamp: new Date().toISOString(),
-    })
-    .select()
-    .single();
+}): Promise<void> => {
+  const { error } = await supabase.rpc('add_music', {
+    p_room_id: params.roomId,
+    p_music_id: params.musicId,
+    p_title: params.title,
+    p_student: params.student,
+  });
 
   if (error) {
     throw new Error(error.message);
   }
-
-  return data as CreateMusicRequestMusicResponse;
 };
 
 /**

--- a/src/app/admin/music-request/actions.ts
+++ b/src/app/admin/music-request/actions.ts
@@ -1,0 +1,35 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { notFound } from 'next/navigation';
+import { supabaseAdmin } from '@/utils/supabase-admin';
+
+/**
+ * 방 삭제. musics 와 room_secrets 는 FK 의 ON DELETE CASCADE 로 함께 정리된다.
+ *
+ * 미들웨어가 /admin 을 개발 환경으로 제한하지만, 서버 액션은 별도의 요청이므로
+ * 여기서도 한 번 더 확인한다.
+ */
+export async function deleteRoomAction(formData: FormData) {
+  if (process.env.NODE_ENV !== 'development') {
+    notFound();
+  }
+
+  if (!supabaseAdmin) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY 가 설정되지 않았습니다.');
+  }
+
+  const roomId = String(formData.get('roomId') ?? '');
+
+  if (!roomId) {
+    throw new Error('roomId 가 없습니다.');
+  }
+
+  const { error } = await supabaseAdmin.from('rooms').delete().eq('id', roomId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidatePath('/admin/music-request');
+}

--- a/src/app/admin/music-request/page.tsx
+++ b/src/app/admin/music-request/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from 'next/navigation';
+import AdminMusicRequestContainer from '@/containers/admin/music-request/admin-music-request-container';
+
+export const metadata = {
+  title: '음악신청 관리',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default function AdminMusicRequestPage() {
+  // 미들웨어가 /admin 을 막지만, matcher 설정 실수 등으로 구멍이 생기지 않도록 여기서도 확인한다.
+  if (process.env.NODE_ENV !== 'development') {
+    notFound();
+  }
+
+  return <AdminMusicRequestContainer />;
+}

--- a/src/containers/admin/music-request/admin-music-request-container.tsx
+++ b/src/containers/admin/music-request/admin-music-request-container.tsx
@@ -1,0 +1,115 @@
+import { formatInTimeZone } from 'date-fns-tz';
+import { Heading1 } from '@/components/heading';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/table';
+import { supabaseAdmin } from '@/utils/supabase-admin';
+import DeleteRoomButton from './delete-room-button';
+
+type AdminRoom = {
+  id: string;
+  roomTitle: string;
+  connectedAt: string;
+  musics: { id: number; title: string; studentName: string }[];
+};
+
+const formatKst = (value: string) =>
+  formatInTimeZone(new Date(value), 'Asia/Seoul', 'yyyy-MM-dd HH:mm');
+
+const getStudentNames = (musics: AdminRoom['musics']) =>
+  Array.from(new Set(musics.map((music) => music.studentName)));
+
+export default async function AdminMusicRequestContainer() {
+  if (!supabaseAdmin) {
+    return (
+      <div className="flex flex-col gap-y-4">
+        <Heading1>음악신청 관리</Heading1>
+        <p className="text-sm text-gray-500 whitespace-pre-line">
+          {
+            'SUPABASE_SERVICE_ROLE_KEY 가 설정되지 않았습니다.\n.env.local 에 추가한 뒤 개발 서버를 다시 시작해주세요.'
+          }
+        </p>
+      </div>
+    );
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('rooms')
+    .select('id, roomTitle, connectedAt, musics(id, title, studentName)')
+    .order('connectedAt', { ascending: false });
+
+  if (error) {
+    return (
+      <div className="flex flex-col gap-y-4">
+        <Heading1>음악신청 관리</Heading1>
+        <p className="text-sm text-red">조회에 실패했습니다: {error.message}</p>
+      </div>
+    );
+  }
+
+  const rooms = (data ?? []) as AdminRoom[];
+  const totalMusicCount = rooms.reduce(
+    (sum, room) => sum + room.musics.length,
+    0,
+  );
+
+  return (
+    <div className="flex flex-col gap-y-6">
+      <Heading1>음악신청 관리</Heading1>
+
+      <p className="text-sm text-gray-500">
+        방 {rooms.length}개 · 신청곡 {totalMusicCount}곡
+      </p>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[22%]">방 제목</TableHead>
+            <TableHead className="w-[14%]">방 ID</TableHead>
+            <TableHead className="w-[14%]">생성</TableHead>
+            <TableHead className="w-[8%]">곡</TableHead>
+            <TableHead className="w-[34%]">학생</TableHead>
+            <TableHead className="w-[8%]" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rooms.map((room) => {
+            const studentNames = getStudentNames(room.musics);
+
+            return (
+              <TableRow key={room.id}>
+                <TableCell className="truncate">{room.roomTitle}</TableCell>
+                <TableCell className="font-mono text-xs text-gray-500">
+                  {room.id.slice(0, 8)}
+                </TableCell>
+                <TableCell className="text-xs text-gray-500">
+                  {formatKst(room.connectedAt)}
+                </TableCell>
+                <TableCell>{room.musics.length}</TableCell>
+                <TableCell className="truncate text-xs text-gray-500">
+                  {studentNames.join(', ') || '-'}
+                </TableCell>
+                <TableCell>
+                  <DeleteRoomButton
+                    roomId={room.id}
+                    roomTitle={room.roomTitle}
+                    musicCount={room.musics.length}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      {rooms.length === 0 && (
+        <p className="text-sm text-gray-500">방이 없습니다.</p>
+      )}
+    </div>
+  );
+}

--- a/src/containers/admin/music-request/delete-room-button.tsx
+++ b/src/containers/admin/music-request/delete-room-button.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/alert-dialog';
+import { deleteRoomAction } from '@/app/admin/music-request/actions';
+
+type Props = {
+  roomId: string;
+  roomTitle: string;
+  musicCount: number;
+};
+
+export default function DeleteRoomButton({
+  roomId,
+  roomTitle,
+  musicCount,
+}: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="red" size="xs">
+          삭제
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>방을 삭제할까요?</AlertDialogTitle>
+          <AlertDialogDescription className="whitespace-pre-line">
+            {`"${roomTitle}" 방과 신청곡 ${musicCount}곡이 함께 삭제됩니다.\n되돌릴 수 없습니다.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel asChild>
+            <Button variant="gray-ghost" size="sm">
+              취소
+            </Button>
+          </AlertDialogCancel>
+          <form action={deleteRoomAction}>
+            <input type="hidden" name="roomId" value={roomId} />
+            <AlertDialogAction asChild>
+              <Button type="submit" variant="red" size="sm">
+                삭제
+              </Button>
+            </AlertDialogAction>
+          </form>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/containers/music-request/music-request-list/music-request-list.tsx
+++ b/src/containers/music-request/music-request-list/music-request-list.tsx
@@ -13,80 +13,85 @@ import {
 } from './music-request-list.utils';
 
 type Props = {
-  roomIds: string[] | null;
+  roomIds: string[];
 };
 
 export default function MusicRequestList({ roomIds }: Props) {
   const router = useRouter();
   const results = useGetMusicRequestRooms(roomIds);
 
-  const rooms = results.map((result) => result.data);
+  // 방마다 독립적으로 처리한다.
+  // 하나를 묶어서 판단하면 조회에 실패한 방 때문에 목록 전체가 로딩 상태에 갇힌다.
+  return results.map((result, index) => {
+    const roomId = roomIds[index];
 
-  if (rooms.includes(undefined)) {
-    return Array.from({ length: 3 }, (_, index) => (
-      <Skeleton key={index} className="w-full aspect-video rounded-md" />
-    ));
-  }
+    if (result.isPending) {
+      return (
+        <Skeleton key={roomId} className="w-full aspect-video rounded-md" />
+      );
+    }
 
-  const reshapeRooms = rooms.map((room, index) => ({
-    ...room,
-    roomId: roomIds[index],
-    headMusic: room.musicList[0],
-  }));
+    // 삭제되었거나 잘못된 id 등으로 조회에 실패한 방은 목록에서 건너뛴다
+    if (result.isError) {
+      return null;
+    }
 
-  return reshapeRooms.map((room) => (
-    <div
-      key={room.roomId}
-      className="cursor-pointer"
-      onClick={() => {
-        router.push(`/music-request/teacher/${room.roomId}`);
-      }}
-    >
-      <div className="w-full aspect-video relative flex justify-center items-center">
-        {hasMusic(room.musicList) ? (
-          <Image
-            className="object-cover rounded-md"
-            src={getMusicRoomImage(room.musicList)}
-            alt=""
-            fill
-          />
-        ) : (
-          <div className="z-10">
-            <TeacherCanIcon width={100} height={100} />
-          </div>
-        )}
-        {hasMusic(room.musicList) ? (
-          <div className="absolute bottom-0 left-0 w-full h-3/4 bg-gradient-to-t from-gray-900 to-transparent rounded-md" />
-        ) : (
-          <div className="absolute bottom-0 left-0 w-full h-full bg-gray-100 dark:bg-gray-900 rounded-md" />
-        )}
-        <div className="absolute bottom-0 left-0 w-full flex flex-col justify-end px-4 py-6 gap-2">
-          <div
-            className={cn(
-              'font-medium text-gray-50 flex items-center',
-              !hasMusic(room.musicList) && 'text-gray-900 dark:text-gray-50',
-            )}
-          >
-            <span>{room.roomTitle}</span>
-            <ChevronRight />
-          </div>
-          {hasMusic(room.musicList) && (
-            <div
-              className={cn(
-                'text-sm text-gray-300 line-clamp-2',
-                !hasMusic(room.musicList) && 'text-gray-900',
-              )}
-            >
-              {getMusicRoomDescription(room.musicList)}
+    const room = result.data;
+
+    return (
+      <div
+        key={roomId}
+        className="cursor-pointer"
+        onClick={() => {
+          router.push(`/music-request/teacher/${roomId}`);
+        }}
+      >
+        <div className="w-full aspect-video relative flex justify-center items-center">
+          {hasMusic(room.musicList) ? (
+            <Image
+              className="object-cover rounded-md"
+              src={getMusicRoomImage(room.musicList)}
+              alt=""
+              fill
+            />
+          ) : (
+            <div className="z-10">
+              <TeacherCanIcon width={100} height={100} />
             </div>
           )}
+          {hasMusic(room.musicList) ? (
+            <div className="absolute bottom-0 left-0 w-full h-3/4 bg-gradient-to-t from-gray-900 to-transparent rounded-md" />
+          ) : (
+            <div className="absolute bottom-0 left-0 w-full h-full bg-gray-100 dark:bg-gray-900 rounded-md" />
+          )}
+          <div className="absolute bottom-0 left-0 w-full flex flex-col justify-end px-4 py-6 gap-2">
+            <div
+              className={cn(
+                'font-medium text-gray-50 flex items-center',
+                !hasMusic(room.musicList) && 'text-gray-900 dark:text-gray-50',
+              )}
+            >
+              <span>{room.roomTitle}</span>
+              <ChevronRight />
+            </div>
+            {hasMusic(room.musicList) && (
+              <div
+                className={cn(
+                  'text-sm text-gray-300 line-clamp-2',
+                  !hasMusic(room.musicList) && 'text-gray-900',
+                )}
+              >
+                {getMusicRoomDescription(room.musicList)}
+              </div>
+            )}
+          </div>
+          {room.musicList.length > 0 && (
+            <Badge className="absolute top-2 right-2">
+              {room.musicList.length}곡
+            </Badge>
+          )}
         </div>
-        {room.musicList.length > 0 && (
-          <Badge className="absolute top-2 right-2">
-            {room.musicList.length}곡
-          </Badge>
-        )}
       </div>
-    </div>
-  ));
+    );
+  });
 }

--- a/src/containers/music-request/music-request-student/music-request-student-main/music-request-student-main.tsx
+++ b/src/containers/music-request/music-request-student/music-request-student-main/music-request-student-main.tsx
@@ -11,11 +11,31 @@ type Props = {
 export default function MusicRequestStudentMain({ roomId }: Props) {
   const { studentName } = useMusicRequestStudentState();
 
-  const { data, isPending } = useGetMusicRequestRoomTitle({ roomId });
+  const { data, isPending, isError } = useGetMusicRequestRoomTitle({ roomId });
 
   if (isPending) {
     // TODO:(김홍동) pending 상태 작업하기
     return null;
+  }
+
+  // 방 조회에 실패하면 이름 입력·곡 신청 단계로 넘어가지 않도록 여기서 멈춘다
+  if (isError) {
+    return (
+      <div className="flex flex-col gap-4 lg:max-w-[600px] lg:my-0 lg:mx-auto">
+        <div className="flex gap-2 items-center text-lg">
+          <TeacherCanIcon width={20} />
+          <span className="text-text-title">티처캔 음악 신청</span>
+        </div>
+        <div className="flex flex-col gap-2 py-12 text-center">
+          <h3 className="text-lg font-medium text-text-title">
+            방을 찾을 수 없어요
+          </h3>
+          <p className="text-sm text-gray-500">
+            선생님께 받은 링크나 QR 코드를 다시 확인해주세요.
+          </p>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -25,7 +45,7 @@ export default function MusicRequestStudentMain({ roomId }: Props) {
         <span className="text-text-title">티처캔 음악 신청</span>
       </div>
       <div className="flex flex-col gap-2 text-sm text-text-title">
-        <span>방 이름: {data?.roomTitle}</span>
+        <span>방 이름: {data.roomTitle}</span>
         {/* {studentName && <span>내 이름: {studentName}</span>} */}
       </div>
       <CreateNamePage roomId={roomId} />

--- a/src/hooks/apis/music-request/use-get-music-request-room-title.ts
+++ b/src/hooks/apis/music-request/use-get-music-request-room-title.ts
@@ -5,5 +5,7 @@ export const useGetMusicRequestRoomTitle = (params: { roomId: string }) => {
   return useQuery({
     queryKey: ['music-request-room-title', params.roomId],
     queryFn: () => getMusicRequestRoomTitle(params),
+    // 없는 방은 재시도해도 결과가 달라지지 않는다
+    retry: false,
   });
 };

--- a/src/hooks/apis/music-request/use-get-music-request-room.ts
+++ b/src/hooks/apis/music-request/use-get-music-request-room.ts
@@ -13,6 +13,8 @@ export const useGetMusicRequestRooms = (roomIds: string[]) => {
     queries: roomIds.map((roomId) => ({
       queryKey: ['music-request-room', roomId],
       queryFn: () => getMusicRequestRoom({ roomId }),
+      // 삭제된 방은 재시도해도 결과가 달라지지 않는다
+      retry: false,
     })),
   });
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,15 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
+  // 관리자 페이지는 로컬 개발 환경에서만 노출한다.
+  // 운영에서는 존재 자체를 드러내지 않도록 리다이렉트가 아닌 404 로 응답한다.
+  if (
+    request.nextUrl.pathname.startsWith('/admin') &&
+    process.env.NODE_ENV !== 'development'
+  ) {
+    return new NextResponse(null, { status: 404 });
+  }
+
   const response = NextResponse.next();
 
   response.headers.set('X-Current-Path', request.nextUrl.pathname);

--- a/src/utils/supabase-admin.ts
+++ b/src/utils/supabase-admin.ts
@@ -1,0 +1,39 @@
+import 'server-only';
+
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * RLS 를 우회하는 관리자용 Supabase 클라이언트.
+ *
+ * service_role 키는 프로젝트 전체에 대한 마스터 키이므로 절대 클라이언트로 넘어가면 안 된다.
+ * - `import 'server-only'` 로 클라이언트 컴포넌트에서 import 하면 빌드가 실패한다.
+ * - 조회 결과만 내려보내고, 키나 이 클라이언트를 props 로 전달하지 않는다.
+ * - 서비스 롤 키는 .env.local 에만 두고 배포 환경에는 넣지 않는다.
+ *
+ * supabase.ts 와 마찬가지로 프로젝트별로 클라이언트를 나눈다.
+ * 환경변수가 없으면 null 을 반환하므로, 사용하는 쪽에서 확인한 뒤 써야 한다.
+ */
+const createAdminClient = (url?: string, serviceRoleKey?: string) => {
+  if (!url || !serviceRoleKey) {
+    return null;
+  }
+
+  return createClient(url, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+};
+
+/** 음악신청 등 기본 프로젝트 */
+export const supabaseAdmin = createAdminClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+
+/**
+ * 투표 기능은 별도 프로젝트를 사용한다(supabase.ts 의 supabaseVote 참고).
+ * 투표 관리자 페이지가 필요해지면 SUPABASE_VOTE_SERVICE_ROLE_KEY 를 추가하고
+ * createAdminClient 로 supabaseVoteAdmin 을 만들어 쓴다.
+ */

--- a/supabase/migrations/20260806010528_add_music_request_rpc.sql
+++ b/supabase/migrations/20260806010528_add_music_request_rpc.sql
@@ -1,0 +1,87 @@
+-- 학생 경로를 RPC 로 분리
+--
+-- 학생 화면이 테이블을 직접 읽거나 쓰지 않도록 두 함수를 추가한다.
+-- 두 함수 모두 roomId 를 인자로 받으므로 방 목록을 열거할 수 없다.
+--
+-- 이 마이그레이션은 순수 추가이며 기존 정책·권한을 바꾸지 않는다.
+-- musics_insert 정책 차단은 클라이언트 배포 확인 후 별도 마이그레이션에서 진행한다.
+
+-- 방 제목 조회 — 학생이 QR 로 받은 roomId 로 방 이름만 확인한다
+CREATE OR REPLACE FUNCTION public.get_room_title(p_room_id uuid)
+  RETURNS text
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  STABLE
+  SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_title text;
+BEGIN
+  SELECT "roomTitle" INTO v_title FROM rooms WHERE id = p_room_id;
+
+  IF v_title IS NULL THEN
+    RAISE EXCEPTION '방을 찾을 수 없어요. 링크를 다시 확인해주세요.';
+  END IF;
+
+  RETURN v_title;
+END;
+$function$;
+
+-- 곡 신청 — 학생과 교사(선생님 이름으로 신청) 양쪽이 사용한다
+--
+-- musics 의 CHECK 제약을 위반하면 Postgres 원문 에러가 사용자에게 노출되므로
+-- 여기서 미리 다듬고 검증해 안내 문구로 바꿔준다.
+CREATE OR REPLACE FUNCTION public.add_music(
+  p_room_id  uuid,
+  p_music_id text,
+  p_title    text,
+  p_student  text
+)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+AS $function$
+DECLARE
+  -- 한 방에 쌓일 수 있는 최대 곡 수 (도배 방어)
+  c_max_music_count constant integer := 200;
+  v_title   text;
+  v_student text;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM rooms WHERE id = p_room_id) THEN
+    RAISE EXCEPTION '방을 찾을 수 없어요. 링크를 다시 확인해주세요.';
+  END IF;
+
+  IF p_music_id IS NULL OR p_music_id !~ '^[A-Za-z0-9_-]{11}$' THEN
+    RAISE EXCEPTION '올바른 유튜브 영상이 아니에요.';
+  END IF;
+
+  -- 제목은 유튜브 API 조회 결과다. 비어 있으면 조회가 끝나기 전에 신청한 경우.
+  v_title := left(btrim(coalesce(p_title, '')), 200);
+  IF v_title = '' THEN
+    RAISE EXCEPTION '곡 정보를 가져오지 못했어요. 잠시 후 다시 시도해주세요.';
+  END IF;
+
+  -- 자른 뒤 끝에 공백이 남을 수 있어 한 번 더 다듬는다 (musics_student_name_trimmed 대응)
+  v_student := btrim(left(btrim(coalesce(p_student, '')), 20));
+  IF v_student = '' THEN
+    RAISE EXCEPTION '이름을 입력해 주세요.';
+  END IF;
+
+  IF (SELECT count(*) FROM musics WHERE "roomId" = p_room_id) >= c_max_music_count THEN
+    RAISE EXCEPTION '이 방은 신청곡이 가득 찼어요. 선생님께 알려주세요.';
+  END IF;
+
+  -- timeStamp 는 컬럼 기본값(now())을 사용해 서버 시계로 기록한다
+  INSERT INTO musics ("roomId", "musicId", title, "studentName")
+  VALUES (p_room_id, p_music_id, v_title, v_student);
+EXCEPTION
+  -- musics_room_music_unique 위반. 클라이언트 사전 조회를 대체하며 경합도 함께 해소된다.
+  WHEN unique_violation THEN
+    RAISE EXCEPTION '이미 신청된 음악이에요.';
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_room_title(uuid) TO anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.add_music(uuid, text, text, text) TO anon, authenticated;


### PR DESCRIPTION
---
PR 1 — `refactor/music-request-student-rpc` → `main`

제목: **음악신청 학생 경로를 RPC로 분리하고 조회 실패 처리를 보강했습니다**

## 작업내용

학생이 테이블을 직접 읽고 쓰던 경로를 RPC로 옮기고, 조회 실패가 조용히 넘어가던 지점들을 처리했습니다.

### 1. 학생 조회·신청 경로를 RPC로 분리

기존에는 학생 화면이 `rooms`·`musics` 테이블에 직접 접근했습니다. 학생에게 조회 권한이 필요 없다는 점을 이용해 두 함수로 좁혔습니다. 두 함수 모두 `roomId`를 인자로 받으므로 방 목록을 열거할 수 없습니다.

**`get_room_title(p_room_id)`** — 방 제목만 반환. 없는 방이면 안내 문구를 담은 예외를 던집니다.

**`add_music(p_room_id, p_music_id, p_title, p_student)`** — 검증을 서버로 옮겼습니다.

| 검사 | 사용자에게 보이는 문구 |
|---|---|
| 방 존재 | 방을 찾을 수 없어요. 링크를 다시 확인해주세요. |
| 유튜브 ID 형식(11자) | 올바른 유튜브 영상이 아니에요. |
| 제목 없음 | 곡 정보를 가져오지 못했어요. 잠시 후 다시 시도해주세요. |
| 이름 빈 값 | 이름을 입력해 주세요. |
| 방 곡수 200 초과 | 이 방은 신청곡이 가득 찼어요. 선생님께 알려주세요. |
| 중복(`unique_violation`) | 이미 신청된 음악이에요. |

부수적으로 정리된 것들:

- **중복 체크의 경합이 해소되었습니다.** 기존에는 `select` 후 `insert`하는 구조라 동시 요청 시 중복이 들어갈 수 있었습니다. 이제 `musics_room_music_unique` 제약 위반을 함수가 잡습니다.
- **유튜브 제목 조회 전에 신청하면 `title`이 `undefined`로 전달되어 NOT NULL 위반이 발생하던 문제**가 안내 문구로 처리됩니다.
- `timeStamp`를 클라이언트가 보내지 않고 컬럼 기본값(`now()`)을 쓰도록 바꿔 서버 시계 기준으로 기록됩니다.
- 실제로 존재하지 않는 `studentId` 컬럼이 들어있던 미사용 타입을 제거했습니다.

### 2. 없는 방으로 접속한 학생에게 안내 화면 표시

`music-request-student-main.tsx`가 `isError`를 확인하지 않아, 방 조회에 실패해도 화면이 그대로 그려졌습니다. 학생이 이름을 입력하고 곡을 고른 **뒤에야** 신청 단계에서 실패를 알게 되는 흐름이었습니다.

이제 조회 실패 시 안내 화면에서 멈춥니다. 없는 방은 재시도해도 결과가 같으므로 `retry: false`를 함께 넣었습니다.

### 3. 조회 실패한 방 때문에 방 목록이 로딩에 갇히는 문제 수정

교사 방 목록에서 로딩과 실패를 같은 조건으로 판단하고 있었습니다.

```ts
const rooms = results.map((result) => result.data);
if (rooms.includes(undefined)) { /* 스켈레톤 */ }
```
result.data는 로딩 중일 때도 실패했을 때도 undefined이므로, 방 하나라도 조회에 실패하면 목록 전체가 영구히 스켈레톤 상태로 남았습니다.

방마다 독립적으로 처리하도록 바꿨습니다.

- isPending / isError를 구분하고, 실패한 방은 목록에서 건너뜁니다
- 스켈레톤 개수가 방 개수를 따르게 됐습니다 (기존에는 방이 1개여도 3개 표시)
- key를 배열 index에서 roomId로 변경
- 사용되지 않던 headMusic 계산 제거

## 리뷰노트

마이그레이션은 이미 원격 DB에 적용된 상태입니다. 20260806010528_add_music_request_rpc.sql은 함수 추가와 GRANT EXECUTE만 하는 순수 추가이며, 기존 정책·권한을 바꾸지 않아 구버전 클라이언트에 영향이 없습니다. 로컬 테스트를 위해 먼저 push했습니다.

후속 작업이 하나 있습니다. 이 PR이 배포된 뒤 별도 마이그레이션으로 직접 INSERT 경로를 닫을 예정입니다.

ALTER POLICY musics_insert ON public.musics WITH CHECK (false);

add_music은 SECURITY DEFINER라 영향받지 않지만, 구버전 클라이언트는 musics에 직접 INSERT하므로 배포 전에 적용하면 학생이 곡을 신청할 수 없게 됩니다. 그래서 이 PR에 포함하지 않았습니다.

**검증 완료**

- 학생 방 입장 / 곡 신청 / 교사 화면 실시간 반영 / 곡 삭제
- 같은 곡 재신청 시 안내 문구 노출
- 없는 roomId로 접속 시 안내 화면 표시
- 교사 화면에서 직접 신청 (학생과 같은 RPC를 사용합니다)
- 방을 두 개 열어 서로의 실시간 이벤트가 섞이지 않음

**남아 있는 것 (이번 범위 아님)**

- rooms·musics의 SELECT 정책이 여전히 전면 공개입니다. 교사가 아직 anon으로 테이블을 읽기 때문에 닫을 수 없고, 교사 인증 도입 이후에 정리할 예정입니다.
- 삭제된 방에 교사가 직접 URL로 접속하면 빈 화면이 표시됩니다. 실시간 훅의 초기 로드 실패가 console.error로만 처리되고 있어, 해당 훅을 수정하는 다음 작업에서 함께 다룹니다.

## 스크린샷
<img width="584" height="303" alt="image" src="https://github.com/user-attachments/assets/7ee5d5b2-2fb1-4f4f-a8a9-ab6673bb7bf8" />
없는 방으로 접속했을 때의 안내 화면만 UI 변경이 있습니다.

### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.

---
PR 2 — `feat/music-request-admin` → `refactor/music-request-student-rpc`

제목: **음악신청 관리자 페이지를 추가했습니다 (개발 환경 전용)**

## 작업내용

방 목록을 확인하고 삭제할 수 있는 관리자 페이지를 추가했습니다. `/admin/music-request` 이며 **로컬 개발 환경에서만 동작합니다.**

### 필요했던 이유

- **방을 삭제할 경로가 없었습니다.** `rooms_delete` 정책이 차단이고 삭제용 RPC도 없어서, 한번 만든 방은 테스트용이든 실사용이든 영구히 남았습니다. 로컬 개발도 운영 DB에 붙기 때문에 개발 중 만든 방이 실제 데이터에 계속 쌓이고 있었습니다.
- **교사가 `secret_token`을 잃으면 복구 수단이 없습니다.** 토큰이 localStorage에만 있어서, 브라우저 데이터를 지우거나 기기를 바꾸면 자기 방의 곡을 삭제할 수 없게 됩니다. 문의가 들어왔을 때 대응할 창구가 필요했습니다.

### 구성

| 파일 | 역할 |
|---|---|
| `utils/supabase-admin.ts` | `service_role` 클라이언트 (`server-only`) |
| `middleware.ts` | `/admin` 경로를 개발 환경으로 제한 |
| `app/admin/music-request/page.tsx` | 개발 환경 확인 후 컨테이너 렌더 |
| `app/admin/music-request/actions.ts` | 방 삭제 서버 액션 |
| `containers/admin/music-request/` | 목록 표(서버 컴포넌트) + 삭제 확인 다이얼로그 |

`supabase-admin.ts`는 `supabase.ts`와 같은 방식으로 프로젝트별 클라이언트를 나눕니다. 투표 기능이 별도 Supabase 프로젝트를 쓰고 있어, 그쪽 관리자 페이지가 필요해지면 `createAdminClient` 한 번 호출로 추가할 수 있게 해뒀습니다.

### 접근 제어 세 겹

1. **미들웨어** — `/admin` 경로는 `NODE_ENV !== 'development'`이면 404. 리다이렉트가 아니라 404로 응답해 존재를 드러내지 않습니다.
2. **페이지와 서버 액션 각각** — 미들웨어 `matcher` 설정 실수로 구멍이 생겨도 막히도록 `notFound()`를 중복으로 넣었습니다. 서버 액션은 별도 요청이라 특히 필요합니다.
3. **`import 'server-only'`** — 클라이언트 컴포넌트에서 import하면 빌드가 실패합니다. 접두사 없는 환경변수가 클라이언트에서 조용히 `undefined`가 되는 사고를 막습니다.

키나 클라이언트를 props로 전달하지 않고 조회 결과만 내려보내므로 RSC 페이로드에도 실리지 않습니다.

### 삭제 시 안전장치

`service_role`은 RLS를 우회하므로 잘못된 삭제를 막아줄 장치가 없습니다. 판단 근거를 표에 함께 표시했습니다.

| 컬럼 | 목적 |
|---|---|
| 방 제목 | 테스트 방 식별 |
| 방 ID (앞 8자) | 문의 대응 시 대조 |
| 생성 시각 (KST) | 오래된 방 판별 |
| 곡 수 | 0곡이면 버려진 방 |
| 학생 이름 (중복 제거) | 실제 수업에 쓰였는지 |

삭제 다이얼로그는 방 제목과 함께 사라지는 곡 수를 보여주고 되돌릴 수 없음을 명시합니다. `musics`와 `room_secrets`가 `ON DELETE CASCADE`로 걸려 있어 `rooms` 한 행 삭제로 함께 정리됩니다.

## 리뷰노트

### ⚠️ `SUPABASE_SERVICE_ROLE_KEY` 를 배포 환경변수에 추가하지 마세요

이 페이지는 코드가 운영에 배포되지만 미들웨어가 404로 응답합니다. 그리고 **운영 환경변수에 키가 없으면 어떤 경우에도 DB에 접근할 수 없습니다.** 이중 차단이 의도된 설계입니다.

`service_role` 키는 RLS를 전부 우회하는 프로젝트 마스터 키입니다. 페이지가 동작하지 않는다는 이유로 배포 환경에 추가하면 이 설계의 안전성이 사라집니다.

로컬에서 사용하려면 `.env.local`에만 추가하세요 (커밋되는 `.env`가 아닙니다).

### 그 외

- **DB 마이그레이션이 없습니다.** 코드만 추가되며 정책·스키마 변경이 없습니다.
- **`dynamic = 'force-dynamic'`** 을 지정해 빌드 시 정적 생성을 시도하지 않게 했습니다.
- 사이드바 메뉴에는 넣지 않았습니다. 개발 환경 전용이라 메뉴에 노출하면 운영 빌드에서도 항목이 보이게 됩니다. URL 직접 입력으로 사용합니다.
- **관리자 작업은 로컬에서만 가능합니다.** 문의 대응 시 `yarn dev`를 띄워야 합니다. 불편하다고 판단되면 이후에 비밀번호 인증을 얹어 운영에서도 접근할 수 있게 할 수 있지만, 그 경우 운영 서버가 마스터 키를 갖게 되는 대가가 있습니다.
- 조회에 `limit`이 없어 방이 1000개를 넘으면 PostgREST 기본 상한에 잘립니다. 현재 규모에서는 문제가 없고, 필요해지면 `range()`로 페이지네이션을 추가하면 됩니다.

**검증 완료**

- 방 목록 표시, 삭제 후 목록에서 사라짐
- 삭제된 방이 교사 방 목록에서 건너뛰어지고 나머지가 정상 표시 (이 PR의 base 브랜치 작업 덕분입니다)
- 키가 없을 때 안내 문구 표시

## 스크린샷
<img width="1605" height="601" alt="image" src="https://github.com/user-attachments/assets/52e16cd7-67aa-4e78-907b-7eab77a88cac" />

### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
