### PR TITLE
fix: 음악신청 곡 직접 INSERT 경로 차단

### DIFF
--- a/supabase/migrations/20260808005302_close_musics_direct_insert.sql
+++ b/supabase/migrations/20260808005302_close_musics_direct_insert.sql
@@ -1,0 +1,10 @@
+-- musics 직접 INSERT 경로 차단
+--
+-- 학생과 교사의 곡 신청이 모두 add_music RPC 를 거치도록 전환되었으므로
+-- 클라이언트가 musics 에 직접 INSERT 하는 경로를 닫는다.
+-- add_music 은 SECURITY DEFINER 라 이 정책의 영향을 받지 않는다.
+--
+-- 이로써 anon 키로 임의의 방에 곡을 밀어넣던 경로가 막힌다.
+
+ALTER POLICY musics_insert ON public.musics
+  WITH CHECK (false);


### PR DESCRIPTION
## 작업내용

`musics` 테이블에 대한 클라이언트의 직접 INSERT 를 차단합니다.

```sql
ALTER POLICY musics_insert ON public.musics WITH CHECK (false);
```
이전 PR에서 학생과 교사의 곡 신청이 모두 **add_music** RPC 를 거치도록 전환됐습니다. 그 함수는 **SECURITY DEFINER** 라 이 정책의 영향을 받지 않으므로, 남아 있던 직접 INSERT 경로만 닫는 마무리 작업입니다.

**막히는 것**: anon 키로 REST API 를 직접 호출해 임의의 방에 곡을 밀어넣는 경로. 그동안은 방 목록을 조회해 유효한 **roomId** 를 얻으면 아무 교실에나 신청곡을 넣을 수 있었습니다.

**유지되는 것**: 앱을 통한 정상적인 곡 신청. **add_music** 이 방 존재 여부·유튜브 ID 형식·이름·중복·방 곡수 상한을 검증한 뒤 삽입합니다.

이로써 musics 와 rooms 에 대한 쓰기 경로가 모두 RPC 로 정리됐습니다.

||경로|
|---|---|
|곡 추가|**add_music**|
|곡 삭제|**delete_music**|
|방 생성|**create_room**|
|그 외 직접 쓰기|전부 차단|


## 리뷰노트

**마이그레이션은 이미 원격 DB에 적용했습니다.** 이 정책은 거부형이라 구버전 클라이언트(직접 INSERT 사용)가 배포되어 있는 동안 적용하면 학생이 곡을 신청할 수 없게 됩니다. 그래서 이전 PR의 배포 완료를 확인한 뒤에 push 했습니다. **머지 후 별도 db push 가 필요 없습니다.**

**검증 완료**

|확인|결과|
|---|---|
|앱에서 학생 곡 신청 → 교사 화면 실시간 반영|정상|
|교사 화면에서 직접 신청|정상|
|POST /rest/v1/musics (curl, anon 키)|42501 RLS 위반|
|POST /rest/v1/rpc/add_music (curl, anon 키)|204|
|같은 곡 재신청|이미 신청된 음악이에요.|

**남아 있는 것**: rooms 와 musics 의 SELECT 정책은 여전히 전면 공개입니다. 교사가 아직 anon 으로 테이블을 읽기 때문인데, 교사 익명 로그인을 도입하는 다음 작업에서 정리할 예정입니다.

## 스크린샷

DB 정책 변경만 있어 UI 변경이 없습니다.

### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
