### PR TITLE
Feat/music request teacher auth

### DIFF
--- a/src/apis/music-request/music-room-storage.ts
+++ b/src/apis/music-request/music-room-storage.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * 교사가 만든 음악신청 방의 secret_token 보관소.
+ *
+ * 이 토큰이 방 소유권의 유일한 증명이고, 목록에 표시할 방도 여기서 나온다.
+ * (예전에는 표시용 `roomIds` 배열과 방별 토큰 키가 따로 있어 서로 어긋날 수 있었다.)
+ */
+
+const STORAGE_KEY = 'music-rooms';
+
+/** 예전 방식: 방마다 별도 키에 토큰을 저장했다 */
+const LEGACY_TOKEN_PREFIX = 'music-room-secret-';
+
+/** roomId → secret_token */
+export type MusicRooms = Record<string, string>;
+
+const parse = (raw: string | null): MusicRooms => {
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * 레거시 키에 있는 방을 흡수하고 원본은 지운다.
+ *
+ * 한 번만 옮기지 않고 읽을 때마다 확인하는 이유는, 배포 직후 구버전 탭에서 만든 방이
+ * 유실되는 창을 없애기 위해서다.
+ *
+ * 흡수한 뒤 레거시 키를 지우는 것이 중요하다. 남겨두면 출처가 둘이 되어,
+ * 로컬 데이터 관리 페이지에서 music-rooms 를 지워도 다음 읽기에서 되살아난다.
+ */
+const absorbLegacy = (rooms: MusicRooms) => {
+  const merged = { ...rooms };
+  let hasChange = false;
+
+  Object.keys(window.localStorage).forEach((key) => {
+    if (!key.startsWith(LEGACY_TOKEN_PREFIX)) {
+      return;
+    }
+
+    const roomId = key.slice(LEGACY_TOKEN_PREFIX.length);
+    const token = window.localStorage.getItem(key);
+
+    if (roomId && token && !merged[roomId]) {
+      merged[roomId] = token;
+    }
+
+    window.localStorage.removeItem(key);
+    hasChange = true;
+  });
+
+  return { merged, hasChange };
+};
+
+const read = (): MusicRooms => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  try {
+    const stored = parse(window.localStorage.getItem(STORAGE_KEY));
+    const { merged, hasChange } = absorbLegacy(stored);
+
+    if (hasChange) {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
+    }
+
+    return merged;
+  } catch (error) {
+    console.error(error);
+    return {};
+  }
+};
+
+const write = (rooms: MusicRooms) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(rooms));
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getMusicRooms = () => read();
+
+export const getSecretToken = (roomId: string) => read()[roomId] ?? null;
+
+export const saveMusicRoom = (roomId: string, token: string) => {
+  write({ ...read(), [roomId]: token });
+};
+
+export const removeMusicRoom = (roomId: string) => {
+  // read() 가 레거시 키를 이미 흡수·정리하므로 여기서는 맵만 다루면 된다
+  const rooms = read();
+  delete rooms[roomId];
+  write(rooms);
+};
+
+/**
+ * 목록 화면용 훅.
+ *
+ * localStorage 는 서버에서 읽을 수 없어 첫 렌더에는 값이 없다.
+ * "아직 못 읽음(isLoaded false)" 과 "읽었는데 방이 없음(roomIds 빈 배열)" 을 구분해야
+ * 로딩 표시와 빈 목록 안내를 올바르게 나눌 수 있다.
+ */
+export const useMusicRooms = () => {
+  const [rooms, setRooms] = useState<MusicRooms>({});
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const refresh = useCallback(() => {
+    setRooms(read());
+    setIsLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const removeRoom = useCallback((roomId: string) => {
+    removeMusicRoom(roomId);
+    setRooms(read());
+  }, []);
+
+  return { roomIds: Object.keys(rooms), isLoaded, refresh, removeRoom };
+};

--- a/src/apis/music-request/musicRequest.ts
+++ b/src/apis/music-request/musicRequest.ts
@@ -96,6 +96,32 @@ export const createMusicRequestMusic = async (params: {
 };
 
 /**
+ * 방 삭제 — musics, room_secrets, room_members 는 FK 의 ON DELETE CASCADE 로 함께 정리된다.
+ *
+ * rooms_delete 정책이 room_members 소속 여부를 확인하므로, 소유자가 아니면
+ * 에러 없이 0건이 삭제된다. 그 경우를 구분하려고 삭제된 행을 돌려받아 확인한다.
+ */
+export const deleteMusicRequestRoom = async (params: {
+  roomId: string;
+}): Promise<void> => {
+  const { data, error } = await supabase
+    .from('rooms')
+    .delete()
+    .eq('id', params.roomId)
+    .select('id');
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data || data.length === 0) {
+    throw new Error(
+      '방을 삭제할 권한이 없어요. 방을 만든 기기에서 시도해주세요.',
+    );
+  }
+};
+
+/**
  * 방 정보 + 음악 목록 조회 (외래키 조인으로 단일 쿼리)
  */
 export const getMusicRequestRoom = async (params: {

--- a/src/apis/music-request/musicRequest.ts
+++ b/src/apis/music-request/musicRequest.ts
@@ -1,26 +1,12 @@
 import { supabase } from '@/utils/supabase';
+import { getSecretToken, saveMusicRoom } from './music-room-storage';
 
 // 입력 UI 에서 쓰는 길이 제한.
 // 실제 강제는 add_music 함수와 musics_student_name_length 제약이 하므로 셋을 함께 맞춰야 한다.
 export const MAX_STUDENT_NAME_LENGTH = 20;
 
-// ─── secret_token 유틸 (방 개설자 인증용) ───
-
-const SECRET_TOKEN_PREFIX = 'music-room-secret-';
-
 function generateSecretToken(): string {
   return crypto.randomUUID();
-}
-
-function saveSecretToken(roomId: string, token: string): void {
-  if (typeof window !== 'undefined') {
-    localStorage.setItem(`${SECRET_TOKEN_PREFIX}${roomId}`, token);
-  }
-}
-
-export function getSecretToken(roomId: string): string | null {
-  if (typeof window === 'undefined') return null;
-  return localStorage.getItem(`${SECRET_TOKEN_PREFIX}${roomId}`);
 }
 
 // ─── Types ───
@@ -63,8 +49,8 @@ export const createMusicRequestRoom = async (params: {
 
   const roomId = data as string;
 
-  // 방 개설자 토큰을 localStorage에 저장
-  saveSecretToken(roomId, secretToken);
+  // 방 개설자 토큰을 보관한다. 이 토큰이 곧 교사의 방 목록이 된다.
+  saveMusicRoom(roomId, secretToken);
 
   return { roomId };
 };

--- a/src/constants/localStorageGroups.ts
+++ b/src/constants/localStorageGroups.ts
@@ -61,9 +61,10 @@ export const LOCAL_STORAGE_KEY_META: Record<
     label: '랜덤 모둠 자동 실행',
     description: '랜덤 모둠 화면에서 자동 실행 여부 설정입니다.',
   },
-  roomIds: {
+  'music-rooms': {
     label: '음악 신청 방 목록',
-    description: '음악 신청에서 사용하는 방(교실) ID 목록입니다.',
+    description:
+      '음악 신청에서 만든 방(교실) 목록입니다. 방을 만든 사람임을 증명하는 값이 함께 저장되며, 지우면 해당 방의 신청곡을 삭제할 수 없게 됩니다.',
   },
   routines: {
     label: '루틴 목록',
@@ -116,7 +117,7 @@ export const LOCAL_STORAGE_GROUPS = [
   {
     id: 'music-request',
     label: '음악신청',
-    keys: ['roomIds'],
+    keys: ['music-rooms'],
   },
   {
     id: 'routine-timer',

--- a/src/containers/data-service/local-data/local-data-container.tsx
+++ b/src/containers/data-service/local-data/local-data-container.tsx
@@ -235,11 +235,11 @@ function getValueDisplay(key: string): DisplayValue {
         };
       }
 
-      if (key === 'roomIds' && Array.isArray(parsed)) {
-        const arr = parsed as string[];
-        if (arr.length === 0) return { summary: '저장된 데이터 없음' };
+      if (key === 'music-rooms' && parsed && typeof parsed === 'object') {
+        const count = Object.keys(parsed).length;
+        if (count === 0) return { summary: '저장된 데이터 없음' };
         return {
-          summary: `방 ${arr.length}개`,
+          summary: `방 ${count}개`,
           detail: undefined,
         };
       }

--- a/src/containers/music-request/music-request-constants.ts
+++ b/src/containers/music-request/music-request-constants.ts
@@ -1,1 +1,0 @@
-export const MAX_MUSIC_COUNT = 3;

--- a/src/containers/music-request/music-request-container.tsx
+++ b/src/containers/music-request/music-request-container.tsx
@@ -46,7 +46,7 @@ const formSchema = z.object({
 
 export default function MusicRequestContainer() {
   const [isOpen, setIsOpen] = useState(false);
-  const { roomIds, isLoaded, refresh } = useMusicRooms();
+  const { roomIds, isLoaded, refresh, removeRoom } = useMusicRooms();
   // 보여줄 방이 있을 때만 세션이 필요하다
   const { isReady: isSessionReady } = useMusicRoomSession({
     enabled: isLoaded && roomIds.length > 0,
@@ -100,7 +100,7 @@ export default function MusicRequestContainer() {
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
         {isLoaded && isSessionReady ? (
-          <MusicRequestList roomIds={roomIds} />
+          <MusicRequestList roomIds={roomIds} onRoomDeleted={removeRoom} />
         ) : (
           Array.from({ length: 3 }, (_, index) => (
             <Skeleton key={index} className="w-full aspect-video rounded-md" />

--- a/src/containers/music-request/music-request-container.tsx
+++ b/src/containers/music-request/music-request-container.tsx
@@ -24,11 +24,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/dialog';
-import useLocalStorage from '@/hooks/useLocalStorage';
+import { useMusicRooms } from '@/apis/music-request/music-room-storage';
 import { Heading1 } from '@/components/heading';
 import { Skeleton } from '@/components/skeleton';
 import MusicRequestList from './music-request-list/music-request-list';
-import { MAX_MUSIC_COUNT } from './music-request-constants';
 
 const ROOM_TITLE_ERROR_MESSAGE = {
   EMPTY_INPUT: '방이름을 입력해 주세요.',
@@ -43,8 +42,7 @@ const formSchema = z.object({
 
 export default function MusicRequestContainer() {
   const [isOpen, setIsOpen] = useState(false);
-  const [isRemoveAllOpen, setIsRemoveAllOpen] = useState(false);
-  const [roomIds, setRoomIds] = useLocalStorage<string[] | null>('roomIds', []);
+  const { roomIds, isLoaded, refresh } = useMusicRooms();
 
   const router = useRouter();
 
@@ -63,7 +61,8 @@ export default function MusicRequestContainer() {
       { roomTitle },
       {
         onSuccess: ({ roomId }) => {
-          setRoomIds((prev) => [...prev, roomId]);
+          // 토큰은 createMusicRequestRoom 이 저장한다. 목록 상태만 다시 읽으면 된다.
+          refresh();
           router.push(`/music-request/teacher/${roomId}`);
         },
         onError: () => {
@@ -75,22 +74,13 @@ export default function MusicRequestContainer() {
     );
   };
 
-  const enableCreateRoom = roomIds && roomIds.length < MAX_MUSIC_COUNT;
-
   return (
     <>
       <div className="flex justify-between items-center mb-6">
         <Heading1 className="mb-6">음악신청 방 목록</Heading1>
-        <Button
-          variant="primary-ghost"
-          size="sm"
-          onClick={() => setIsRemoveAllOpen(true)}
-        >
-          음악신청 방 목록 초기화
-        </Button>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
-        {roomIds ? (
+        {isLoaded ? (
           <MusicRequestList roomIds={roomIds} />
         ) : (
           Array.from({ length: 3 }, (_, index) => (
@@ -109,11 +99,6 @@ export default function MusicRequestContainer() {
           <DialogHeader>
             <DialogTitle>음악신청 방 만들기</DialogTitle>
             <DialogDescription>
-              {!enableCreateRoom ? (
-                <span className="text-sm text-gray-500 whitespace-pre-line">
-                  {`목록에 최대 ${MAX_MUSIC_COUNT}개의 방만 저장할 수 있어요.\n음악신청 방 > 방 정보 > 목록 노출에서 미노출을 처리할 수 있어요.`}
-                </span>
-              ) : null}
               <Form {...form}>
                 <form
                   onSubmit={form.handleSubmit(() =>
@@ -132,14 +117,12 @@ export default function MusicRequestContainer() {
                               type="text"
                               {...field}
                               placeholder="방 이름을 입력해주세요."
-                              disabled={!enableCreateRoom}
                             />
                           </FormControl>
                           <Button
                             type="submit"
                             variant="primary"
                             className="w-[120px]"
-                            disabled={!enableCreateRoom}
                           >
                             {isPending ? (
                               <LoaderCircle
@@ -160,38 +143,6 @@ export default function MusicRequestContainer() {
                 </form>
               </Form>
             </DialogDescription>
-          </DialogHeader>
-        </DialogContent>
-      </Dialog>
-      <Dialog open={isRemoveAllOpen} onOpenChange={setIsRemoveAllOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>음악신청 방 목록 초기화</DialogTitle>
-            <DialogDescription>
-              <span className="text-sm text-gray-500 whitespace-pre-line">
-                목록에서만 방들이 제거됩니다. 방 ID를 알고 있다면 URL로 직접
-                접근할 수 있어요.
-              </span>
-            </DialogDescription>
-            <div className="flex justify-end gap-2 pt-2">
-              <Button
-                variant="gray-ghost"
-                size="sm"
-                onClick={() => setIsRemoveAllOpen(false)}
-              >
-                취소
-              </Button>
-              <Button
-                variant="red"
-                size="sm"
-                onClick={() => {
-                  setRoomIds([]);
-                  setIsRemoveAllOpen(false);
-                }}
-              >
-                초기화하기
-              </Button>
-            </div>
           </DialogHeader>
         </DialogContent>
       </Dialog>

--- a/src/containers/music-request/music-request-container.tsx
+++ b/src/containers/music-request/music-request-container.tsx
@@ -25,6 +25,10 @@ import {
   DialogTitle,
 } from '@/components/dialog';
 import { useMusicRooms } from '@/apis/music-request/music-room-storage';
+import {
+  ensureMusicRoomSession,
+  useMusicRoomSession,
+} from '@/hooks/apis/music-request/use-music-room-session';
 import { Heading1 } from '@/components/heading';
 import { Skeleton } from '@/components/skeleton';
 import MusicRequestList from './music-request-list/music-request-list';
@@ -43,6 +47,10 @@ const formSchema = z.object({
 export default function MusicRequestContainer() {
   const [isOpen, setIsOpen] = useState(false);
   const { roomIds, isLoaded, refresh } = useMusicRooms();
+  // 보여줄 방이 있을 때만 세션이 필요하다
+  const { isReady: isSessionReady } = useMusicRoomSession({
+    enabled: isLoaded && roomIds.length > 0,
+  });
 
   const router = useRouter();
 
@@ -56,7 +64,18 @@ export default function MusicRequestContainer() {
     reValidateMode: 'onSubmit',
   });
 
-  const handleRoomTitleSubmit = (roomTitle: string) => {
+  const handleRoomTitleSubmit = async (roomTitle: string) => {
+    // create_room 이 auth.uid() 로 소유자를 등록하므로 세션이 먼저 있어야 한다
+    try {
+      await ensureMusicRoomSession();
+    } catch {
+      form.setError('roomTitle', {
+        message: ROOM_TITLE_ERROR_MESSAGE.API_ERROR,
+      });
+
+      return;
+    }
+
     createRoom(
       { roomTitle },
       {
@@ -80,7 +99,7 @@ export default function MusicRequestContainer() {
         <Heading1 className="mb-6">음악신청 방 목록</Heading1>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
-        {isLoaded ? (
+        {isLoaded && isSessionReady ? (
           <MusicRequestList roomIds={roomIds} />
         ) : (
           Array.from({ length: 3 }, (_, index) => (

--- a/src/containers/music-request/music-request-list/delete-room-button/delete-room-button.tsx
+++ b/src/containers/music-request/music-request-list/delete-room-button/delete-room-button.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from '@/components/alert-dialog';
+import { Button } from '@/components/button';
+import { useToast } from '@/hooks/use-toast';
+import { useDeleteMusicRequestRoom } from '@/hooks/apis/music-request/use-delete-music-request-room';
+
+type Props = {
+  roomId: string;
+  roomTitle: string;
+  musicCount: number;
+  onDeleted: (roomId: string) => void;
+};
+
+export default function DeleteRoomButton({
+  roomId,
+  roomTitle,
+  musicCount,
+  onDeleted,
+}: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { toast } = useToast();
+  const { mutate: deleteRoom, isPending } = useDeleteMusicRequestRoom();
+
+  // 카드 전체가 방 상세로 이동하는 버튼이라 클릭이 전파되지 않게 막는다
+  const stopPropagation = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+  };
+
+  const handleDelete = () => {
+    deleteRoom(
+      { roomId },
+      {
+        onSuccess: () => {
+          setIsOpen(false);
+          onDeleted(roomId);
+          toast({ title: '방을 삭제했어요.', variant: 'success' });
+        },
+        onError: (error) => {
+          setIsOpen(false);
+          toast({ title: error.message, variant: 'error' });
+        },
+      },
+    );
+  };
+
+  return (
+    <div
+      onClick={stopPropagation}
+      onKeyDown={stopPropagation}
+      role="presentation"
+    >
+      <Button
+        variant="primary-ghost"
+        size="icon"
+        className="absolute top-1 right-1 z-10 h-8 w-8 bg-gray-50/80 dark:bg-gray-900/80"
+        aria-label={`${roomTitle} 방 삭제`}
+        onClick={() => setIsOpen(true)}
+      >
+        <Trash2 size={16} />
+      </Button>
+
+      <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+        <AlertDialogContent>
+          <AlertDialogTitle>방을 삭제할까요?</AlertDialogTitle>
+          <AlertDialogDescription className="whitespace-pre-line">
+            {`"${roomTitle}" 방과 신청곡 ${musicCount}곡이 함께 삭제돼요.\n되돌릴 수 없어요.`}
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <Button
+              variant="gray-ghost"
+              size="sm"
+              onClick={() => setIsOpen(false)}
+            >
+              취소
+            </Button>
+            <Button
+              variant="red"
+              size="sm"
+              disabled={isPending}
+              onClick={handleDelete}
+            >
+              삭제
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/containers/music-request/music-request-list/music-request-list.tsx
+++ b/src/containers/music-request/music-request-list/music-request-list.tsx
@@ -11,12 +11,14 @@ import {
   getMusicRoomDescription,
   hasMusic,
 } from './music-request-list.utils';
+import DeleteRoomButton from './delete-room-button/delete-room-button';
 
 type Props = {
   roomIds: string[];
+  onRoomDeleted: (roomId: string) => void;
 };
 
-export default function MusicRequestList({ roomIds }: Props) {
+export default function MusicRequestList({ roomIds, onRoomDeleted }: Props) {
   const router = useRouter();
   const results = useGetMusicRequestRooms(roomIds);
 
@@ -47,6 +49,12 @@ export default function MusicRequestList({ roomIds }: Props) {
         }}
       >
         <div className="w-full aspect-video relative flex justify-center items-center">
+          <DeleteRoomButton
+            roomId={roomId}
+            roomTitle={room.roomTitle}
+            musicCount={room.musicList.length}
+            onDeleted={onRoomDeleted}
+          />
           {hasMusic(room.musicList) ? (
             <Image
               className="object-cover rounded-md"
@@ -86,7 +94,7 @@ export default function MusicRequestList({ roomIds }: Props) {
             )}
           </div>
           {room.musicList.length > 0 && (
-            <Badge className="absolute top-2 right-2">
+            <Badge className="absolute top-2 left-2">
               {room.musicList.length}곡
             </Badge>
           )}

--- a/src/containers/music-request/music-request-teacher/music-request-teacher-container.tsx
+++ b/src/containers/music-request/music-request-teacher/music-request-teacher-container.tsx
@@ -1,13 +1,61 @@
 'use client';
 
+import { useMusicRooms } from '@/apis/music-request/music-room-storage';
+import { useMusicRoomSession } from '@/hooks/apis/music-request/use-music-room-session';
+import LoadingSpinner from '@/components/loading-spinner';
 import MusicRequestTeacherMain from './music-request-teacher-main/music-request-teacher-main';
 
-export default function MusicRequestTeacherContainer({
-  params,
-}: {
+type Props = {
   params: {
     roomId: string;
   };
-}) {
+};
+
+function TeacherMessage({ title, description }: Record<string, string>) {
+  return (
+    <div className="flex flex-col gap-2 py-12 text-center">
+      <h3 className="text-lg font-medium text-text-title">{title}</h3>
+      <p className="text-sm text-gray-500">{description}</p>
+    </div>
+  );
+}
+
+export default function MusicRequestTeacherContainer({ params }: Props) {
+  const { roomIds, isLoaded } = useMusicRooms();
+
+  // 이 기기에서 만든 방만 조회할 수 있다. 남의 방이면 세션을 만들 이유도 없다.
+  const isOwnedRoom = roomIds.includes(params.roomId);
+
+  const { isReady, isError } = useMusicRoomSession({
+    enabled: isLoaded && isOwnedRoom,
+  });
+
+  if (!isLoaded) {
+    return <LoadingSpinner />;
+  }
+
+  if (!isOwnedRoom) {
+    return (
+      <TeacherMessage
+        title="이 기기에서 만든 방이 아니에요"
+        description="방을 만든 기기에서 열어주세요. 방이 삭제되었을 수도 있어요."
+      />
+    );
+  }
+
+  if (isError) {
+    return (
+      <TeacherMessage
+        title="방 정보를 불러오지 못했어요"
+        description="잠시 후 페이지를 새로고침해주세요."
+      />
+    );
+  }
+
+  // 소유권 등록이 끝나기 전에 구독을 걸면 실시간 이벤트를 받지 못한다
+  if (!isReady) {
+    return <LoadingSpinner />;
+  }
+
   return <MusicRequestTeacherMain roomId={params.roomId} />;
 }

--- a/src/containers/music-request/music-request-teacher/music-request-teacher-main/music-list/music-card/music-card.tsx
+++ b/src/containers/music-request/music-request-teacher/music-request-teacher-main/music-list/music-card/music-card.tsx
@@ -41,16 +41,6 @@ export default function MusicCard({
     currentMusicId !== null && currentMusicId === video.musicId;
 
   const handleDeleteMusic = async () => {
-    // NOTE:(김홍동) 예시 페이지에서는 음악 삭제 기능 막기
-    if (roomId === 'c15fa864-8719-41e9-99f4-4bcf64086d42') {
-      toast({
-        title: '이 페이지에서는 음악을 삭제할 수 없어요.',
-        variant: 'default',
-      });
-
-      return;
-    }
-
     if (isSelectedMusic) {
       toast({
         title: '재생 중인 곡은 삭제할 수 없어요.',

--- a/src/containers/music-request/music-request-teacher/music-request-teacher-main/room-info/room-info.tsx
+++ b/src/containers/music-request/music-request-teacher/music-request-teacher-main/room-info/room-info.tsx
@@ -1,18 +1,4 @@
-import { Button } from '@/components/button';
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogTitle,
-} from '@/components/alert-dialog';
-import { Label } from '@/components/label';
-import { Switch } from '@/components/switch';
-import { useToast } from '@/hooks/use-toast';
-import useLocalStorage from '@/hooks/useLocalStorage';
 import { QRCodeCanvas } from 'qrcode.react';
-import { useState } from 'react';
-import { MAX_MUSIC_COUNT } from '@/containers/music-request/music-request-constants';
 
 type Props = {
   roomTitle: string;
@@ -20,37 +6,6 @@ type Props = {
 };
 
 export default function RoomInfo({ roomTitle, roomId }: Props) {
-  const { toast } = useToast();
-
-  const [roomIds, setRoomIds] = useLocalStorage<string[] | null>('roomIds', []);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const isInList = roomIds?.includes(roomId) ?? true;
-
-  const toggleSave = () => {
-    if (isInList) {
-      setIsModalOpen(true);
-      setRoomIds(roomIds?.filter((id) => id !== roomId));
-
-      return;
-    }
-
-    if (roomIds.length >= MAX_MUSIC_COUNT) {
-      toast({
-        title: `목록에 최대 ${MAX_MUSIC_COUNT}개의 방만 노출할 수 있어요.`,
-        variant: 'error',
-      });
-
-      return;
-    }
-
-    toast({
-      title: '목록에 추가되었어요.',
-      variant: 'success',
-    });
-
-    setRoomIds([...roomIds, roomId]);
-  };
-
   // NOTE:(김홍동) 예시 페이지에서는 학생 초대 막기
   if (roomId === 'c15fa864-8719-41e9-99f4-4bcf64086d42') {
     return (
@@ -78,41 +33,6 @@ export default function RoomInfo({ roomTitle, roomId }: Props) {
           size={380}
         />
       </div>
-      <div className="w-hull h-[1px] bg-gray-100 dark:bg-gray-800" />
-      <Label className="flex items-center justify-between gap-x-2">
-        <span className="pl-2 text-text-title">목록 노출</span>
-        <Switch checked={isInList} onClick={toggleSave} />
-      </Label>
-
-      <AlertDialog open={isModalOpen} onOpenChange={setIsModalOpen}>
-        <AlertDialogContent>
-          <AlertDialogTitle>{roomTitle} 미노출</AlertDialogTitle>
-          <AlertDialogDescription>
-            해당 음악신청 방을 목록에서 미노출하시겠습니까?
-          </AlertDialogDescription>
-          <AlertDialogFooter>
-            <Button
-              variant="gray-ghost"
-              size="sm"
-              onClick={() => {
-                setIsModalOpen(false);
-                setRoomIds([...roomIds, roomId]);
-              }}
-            >
-              취소
-            </Button>
-            <Button
-              variant="red"
-              size="sm"
-              onClick={() => {
-                setIsModalOpen(false);
-              }}
-            >
-              미노출
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/src/containers/music-request/music-request-teacher/music-request-teacher-main/room-info/room-info.tsx
+++ b/src/containers/music-request/music-request-teacher/music-request-teacher-main/room-info/room-info.tsx
@@ -6,22 +6,6 @@ type Props = {
 };
 
 export default function RoomInfo({ roomTitle, roomId }: Props) {
-  // NOTE:(김홍동) 예시 페이지에서는 학생 초대 막기
-  if (roomId === 'c15fa864-8719-41e9-99f4-4bcf64086d42') {
-    return (
-      <div className="flex flex-col gap-4 mt-12 justify-center items-center">
-        <div className="text-center text-sm text-gray-500">
-          <span>선생님들께 예시로 보여드리는 음악 신청 페이지예요.</span>
-          <br />
-          <span>
-            직접 방을 만들어 학생들을 초대해보시면 신청 기능을 더 자세히
-            체험해보실 수 있어요.
-          </span>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col gap-4 py-4 rounded">
       <div className="px-2 text-gray-700 dark:text-gray-200">

--- a/src/hooks/apis/music-request/use-delete-music-request-room.ts
+++ b/src/hooks/apis/music-request/use-delete-music-request-room.ts
@@ -1,0 +1,8 @@
+import { deleteMusicRequestRoom } from '@/apis/music-request/musicRequest';
+import { useMutation } from '@tanstack/react-query';
+
+export const useDeleteMusicRequestRoom = () => {
+  return useMutation({
+    mutationFn: deleteMusicRequestRoom,
+  });
+};

--- a/src/hooks/apis/music-request/use-music-realtime.ts
+++ b/src/hooks/apis/music-request/use-music-realtime.ts
@@ -17,9 +17,17 @@ type PendingEvent =
  *
  * 핵심 설계:
  * 1) cancelled 플래그 — Strict Mode 이중 마운트 시 stale 클로저가 상태를 오염시키지 않도록 차단
- * 2) 구독 먼저 → 초기 로드 나중 — 구독이 확정(SUBSCRIBED)된 후 초기 데이터를 불러와서 누락 방지
- * 3) 이벤트 버퍼링 — 초기 로드 완료 전 도착한 Realtime 이벤트를 버퍼에 쌓고,
+ * 2) 채널 신원 비교 — connect() 는 이전 채널을 정리하며 그 채널의 콜백을 CLOSED 로 동기 호출한다.
+ *    어느 채널에서 온 콜백인지 구분하지 않으면 재시도가 자기 자신을 물고 도는 루프가 된다.
+ * 3) 구독 먼저 → 초기 로드 나중 — 구독이 확정(SUBSCRIBED)된 후 초기 데이터를 불러와서 누락 방지
+ * 4) 이벤트 버퍼링 — 초기 로드 완료 전 도착한 Realtime 이벤트를 버퍼에 쌓고,
  *    로드 완료 후 knownIds 기준으로 중복을 걸러내며 replay
+ *
+ * 개발 모드 주의:
+ * StrictMode 이중 마운트로 채널이 만들어졌다 곧바로 정리되는데, supabase 는 마지막 채널이
+ * 사라질 때 소켓까지 끊는다. 내려가는 소켓 위에서 다음 채널이 join 을 시도해 10초(기본 join
+ * 타임아웃)를 기다린 뒤에야 연결되고, 콘솔에 "WebSocket is closed before the connection is
+ * established" 가 찍힌다. 프로덕션 빌드에서는 재현되지 않으므로 쫓지 않아도 된다.
  */
 export function useMusicRealtime(
   roomId: string,
@@ -53,8 +61,11 @@ export function useMusicRealtime(
         retryTimerRef.current = null;
       }
       if (channel) {
-        supabase.removeChannel(channel);
+        // removeChannel 은 그 채널의 subscribe 콜백을 CLOSED 로 동기 호출한다.
+        // channel 을 먼저 비워야 그 콜백이 "교체된 채널"로 판정되어 재시도를 유발하지 않는다.
+        const previousChannel = channel;
         channel = null;
+        supabase.removeChannel(previousChannel);
       }
     };
 
@@ -87,8 +98,12 @@ export function useMusicRealtime(
       pendingEvents.length = 0;
       setConnectionStatus('reconnecting');
 
-      channel = supabase
-        .channel(`room-${roomId}`)
+      // cleanupChannel() 이 이전 채널을 닫으면 그 채널의 콜백이 CLOSED 로 뒤늦게 불린다.
+      // 어느 채널에서 온 콜백인지 구분하지 않으면 재시도가 스스로를 물고 도는 루프가 된다.
+      const nextChannel = supabase.channel(`room-${roomId}`);
+      channel = nextChannel;
+
+      nextChannel
         .on(
           'postgres_changes',
           {
@@ -133,7 +148,8 @@ export function useMusicRealtime(
           },
         )
         .subscribe(async (status) => {
-          if (cancelled) return;
+          // 이미 교체된 채널에서 온 콜백은 무시한다
+          if (cancelled || channel !== nextChannel) return;
 
           if (status === 'SUBSCRIBED') {
             retryCountRef.current = 0;
@@ -160,16 +176,18 @@ export function useMusicRealtime(
             initialLoadDone = true;
             flushPendingEvents();
             setConnectionStatus('connected');
-          } else if (status === 'CHANNEL_ERROR') {
-            if (retryCountRef.current < MAX_RETRIES) {
-              const delay = BASE_DELAY_MS * 2 ** retryCountRef.current;
-              retryCountRef.current += 1;
-              setConnectionStatus('reconnecting');
-              retryTimerRef.current = setTimeout(connect, delay);
-            } else {
-              setConnectionStatus('disconnected');
-            }
-          } else if (status === 'CLOSED') {
+
+            return;
+          }
+
+          // SUBSCRIBED 외의 상태(CHANNEL_ERROR / TIMED_OUT / CLOSED)는 모두 재시도 대상이다.
+          // 하나라도 빠뜨리면 그 상태에 도달했을 때 'reconnecting' 인 채로 멈춘다.
+          if (retryCountRef.current < MAX_RETRIES) {
+            const delay = BASE_DELAY_MS * 2 ** retryCountRef.current;
+            retryCountRef.current += 1;
+            setConnectionStatus('reconnecting');
+            retryTimerRef.current = setTimeout(connect, delay);
+          } else {
             setConnectionStatus('disconnected');
           }
         });
@@ -188,6 +206,20 @@ export function useMusicRealtime(
     retryCountRef.current = 0;
     setReconnectKey((k) => k + 1);
   }, []);
+
+  // 익명 세션도 주기적으로 토큰을 갱신하고, 그때 realtime 소켓이 재설정된다.
+  // 교사가 수업 내내 화면을 켜두는 사용 패턴이라 갱신 시점에 조용히 끊기면 체감이 크다.
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'TOKEN_REFRESHED') {
+        reconnect();
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [reconnect]);
 
   return [connectionStatus, reconnect] as const;
 }

--- a/src/hooks/apis/music-request/use-music-room-session.ts
+++ b/src/hooks/apis/music-request/use-music-room-session.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getMusicRooms } from '@/apis/music-request/music-room-storage';
+import { supabase } from '@/utils/supabase';
+
+/**
+ * 교사 화면에서 익명 세션을 확보하고, 보관 중인 secret_token 으로 방 소유권을 등록한다.
+ *
+ * 조회 정책이 room_members 를 기준으로 판단하므로 등록이 끝나기 전에 데이터를 읽거나
+ * realtime 을 구독하면 아무것도 받지 못한다. 화면은 isReady 가 true 가 된 뒤에 그려야 한다.
+ *
+ * 세션은 꼭 필요할 때만 만든다. 익명 계정은 auth.users 에 영구히 쌓이므로,
+ * 방이 하나도 없는 교사가 페이지를 구경만 하고 나가는 경우까지 계정을 만들면
+ * 실제 사용자 수와 계정 수가 어긋난다.
+ *
+ * 학생 화면에서는 호출하지 않는다. 학생은 인증 없이 RPC 만 사용한다.
+ */
+
+/** 한 번 등록한 사용자는 페이지 이동마다 다시 등록하지 않는다 */
+let claimedUserId: string | null = null;
+
+/** 세션이 없으면 익명으로 로그인한다. 방 생성처럼 즉시 세션이 필요한 곳에서도 쓴다. */
+export const ensureMusicRoomSession = async () => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session) {
+    return session.user.id;
+  }
+
+  const { data, error } = await supabase.auth.signInAnonymously();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data.user?.id ?? null;
+};
+
+const claimStoredRooms = async () => {
+  // 이미 등록된 방은 ON CONFLICT DO NOTHING 으로 조용히 넘어간다.
+  // 삭제된 방은 secret 이 함께 사라져 실패하지만, 다른 방 등록을 막지 않는다.
+  await Promise.all(
+    Object.entries(getMusicRooms()).map(([roomId, token]) =>
+      supabase.rpc('claim_room', {
+        p_room_id: roomId,
+        p_secret_token: token,
+      }),
+    ),
+  );
+};
+
+type Params = {
+  /** 읽을 방이 있을 때만 세션을 만든다 */
+  enabled: boolean;
+};
+
+export const useMusicRoomSession = ({ enabled }: Params) => {
+  const [isPrepared, setIsPrepared] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  const prepare = useCallback(async () => {
+    try {
+      const userId = await ensureMusicRoomSession();
+
+      if (userId && claimedUserId !== userId) {
+        await claimStoredRooms();
+        claimedUserId = userId;
+      }
+
+      setIsPrepared(true);
+    } catch (error) {
+      console.error('음악신청 세션 준비 실패:', error);
+      setIsError(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    setIsPrepared(false);
+    prepare();
+  }, [enabled, prepare]);
+
+  // enabled 를 파생값으로 함께 판단한다.
+  // 상태로만 두면 enabled 가 켜지기 한 렌더 전에 준비 완료로 보여서,
+  // 화면이 잠깐 열렸다 닫히며 realtime 연결이 한 번 버려진다.
+  return { isReady: !enabled || isPrepared, isError };
+};

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -8,7 +8,6 @@ type LocalStorageKey =
   | 'selectedSchool'
   | 'allergies'
   | 'routines'
-  | 'roomIds'
   | 'random-pick-list'
   | 'student-data'
   | 'student-data-sets'

--- a/supabase/migrations/20260808053056_add_room_membership.sql
+++ b/supabase/migrations/20260808053056_add_room_membership.sql
@@ -1,0 +1,109 @@
+-- 교사 방 소유권을 서버에 등록하기 위한 기반
+--
+-- 지금까지 방 소유권은 브라우저 localStorage 의 secret_token 뿐이었다.
+-- RLS 는 그 값을 볼 수 없어서 조회 범위를 방 단위로 좁힐 수 없었다.
+--
+-- 교사가 익명 로그인 후 secret_token 으로 소유권을 주장하면(claim_room)
+-- room_members 에 기록되고, 이후 정책이 auth.uid() 로 판단할 수 있게 된다.
+-- secret_token 은 영구 소유권 증명으로 그대로 남는다. 익명 세션을 잃어도
+-- 다시 로그인해 claim_room 을 호출하면 복구된다.
+--
+-- 이 마이그레이션은 추가와 허용만 한다. 구버전 클라이언트에 영향이 없으므로
+-- 배포 전에 push 해도 안전하다. 조회 범위 제한은 배포 확인 후 별도 마이그레이션에서 한다.
+
+-- ─────────────────────────────────────────────
+-- room_members
+-- ─────────────────────────────────────────────
+
+CREATE TABLE public.room_members (
+  user_id    uuid                     NOT NULL,
+  room_id    uuid                     NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  PRIMARY KEY (user_id, room_id)
+);
+
+-- 익명 계정을 정리하면 소속도 함께 사라진다
+ALTER TABLE public.room_members
+  ADD CONSTRAINT room_members_user_id_fkey
+  FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.room_members
+  ADD CONSTRAINT room_members_room_id_fkey
+  FOREIGN KEY (room_id) REFERENCES public.rooms(id) ON DELETE CASCADE;
+
+-- room_id 단독 조회(방 삭제 시 CASCADE)를 위한 인덱스. PK 는 user_id 가 선두라 쓰이지 않는다.
+CREATE INDEX room_members_room_id_idx ON public.room_members (room_id);
+
+ALTER TABLE public.room_members ENABLE ROW LEVEL SECURITY;
+
+-- 클라이언트는 이 테이블을 직접 만지지 않는다. 오직 SECURITY DEFINER 함수만 접근한다.
+CREATE POLICY room_members_select ON public.room_members FOR SELECT USING (false);
+CREATE POLICY room_members_insert ON public.room_members FOR INSERT WITH CHECK (false);
+CREATE POLICY room_members_update ON public.room_members FOR UPDATE USING (false);
+CREATE POLICY room_members_delete ON public.room_members FOR DELETE USING (false);
+
+-- 기본 권한(ALTER DEFAULT PRIVILEGES)으로 자동 부여되는 테이블 권한을 회수한다.
+-- RLS 가 이미 막고 있지만, 정책이 잘못 바뀌어도 뚫리지 않도록 두 겹으로 둔다.
+REVOKE ALL ON public.room_members FROM anon, authenticated;
+
+-- ─────────────────────────────────────────────
+-- 소속 판정 헬퍼
+-- ─────────────────────────────────────────────
+
+-- 정책 안에서 room_members 를 직접 조회하면 그 테이블의 RLS 까지 평가된다.
+-- SECURITY DEFINER 로 감싸 RLS 를 우회하고, STABLE 로 표시해 행마다 재실행되지 않게 한다.
+CREATE OR REPLACE FUNCTION public.is_room_member(p_room_id uuid)
+  RETURNS boolean
+  LANGUAGE sql
+  SECURITY DEFINER
+  STABLE
+  SET search_path TO 'public'
+AS $function$
+  SELECT EXISTS (
+    SELECT 1 FROM room_members
+    WHERE room_id = p_room_id
+      AND user_id = auth.uid()
+  );
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.is_room_member(uuid) TO anon, authenticated;
+
+-- ─────────────────────────────────────────────
+-- 소유권 주장
+-- ─────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.claim_room(p_room_id uuid, p_secret_token uuid)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION '로그인이 필요해요.';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM room_secrets
+    WHERE room_id = p_room_id
+      AND secret_token = p_secret_token
+  ) THEN
+    RAISE EXCEPTION '방을 만든 기기에서만 등록할 수 있어요.';
+  END IF;
+
+  INSERT INTO room_members (user_id, room_id)
+  VALUES (auth.uid(), p_room_id)
+  ON CONFLICT DO NOTHING;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.claim_room(uuid, uuid) TO authenticated;
+
+-- ─────────────────────────────────────────────
+-- 방 삭제 개방
+-- ─────────────────────────────────────────────
+
+-- 소속된 방만 지울 수 있다. musics, room_secrets, room_members 는 CASCADE 로 함께 정리된다.
+-- 허용 방향이라 구버전 클라이언트에 영향이 없다(방 삭제를 호출하지 않는다).
+ALTER POLICY rooms_delete ON public.rooms
+  USING (is_room_member(id));

--- a/supabase/migrations/20260808062158_create_room_registers_member.sql
+++ b/supabase/migrations/20260808062158_create_room_registers_member.sql
@@ -1,0 +1,36 @@
+-- 방을 만든 사람을 곧바로 소유자로 등록한다
+--
+-- create_room 이 room_members 까지 함께 기록하지 않으면, 방금 만든 방은
+-- 클라이언트가 별도로 claim_room 을 호출하기 전까지 조회할 수 없다.
+-- 방 생성 · 토큰 저장 · 소유권 등록을 한 트랜잭션으로 묶는다.
+--
+-- 세션이 없는 호출(구버전 클라이언트)에서는 auth.uid() 가 NULL 이므로 등록만 건너뛴다.
+-- 기존 동작이 그대로 유지되므로 배포 전에 push 해도 안전하다.
+
+CREATE OR REPLACE FUNCTION public.create_room (
+  p_room_title   text,
+  p_secret_token uuid
+)
+  RETURNS uuid
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+AS $function$
+  DECLARE
+    v_room_id UUID := gen_random_uuid();
+  BEGIN
+    INSERT INTO rooms (id, "roomTitle", "connectedAt")
+    VALUES (v_room_id, p_room_title, now());
+
+    INSERT INTO room_secrets (room_id, secret_token)
+    VALUES (v_room_id, p_secret_token);
+
+    -- 로그인한 교사라면 소유자로 등록한다. secret_token 은 영구 증명으로 그대로 남는다.
+    IF auth.uid() IS NOT NULL THEN
+      INSERT INTO room_members (user_id, room_id)
+      VALUES (auth.uid(), v_room_id);
+    END IF;
+
+    RETURN v_room_id;
+  END;
+  $function$;


### PR DESCRIPTION
## 작업내용

교사의 방 소유권을 브라우저 localStorage 에서만 판단하던 구조를 서버(`room_members`)로 옮기고, 그 위에 방 삭제 기능을 올렸습니다. 조회 범위를 방 단위로 제한하기 위한 기반 작업입니다.

### 배경

지금까지 방 소유권의 유일한 증거는 브라우저 localStorage 의 `secret_token` 이었습니다. RLS 는 이 값을 볼 수 없어서 조회 정책을 `USING (true)` 로 열어둘 수밖에 없었고, anon 키로 모든 교실의 신청곡과 학생 이름을 조회할 수 있는 상태였습니다.

교사가 익명 로그인한 뒤 보관 중인 토큰으로 소유권을 주장하면, 정책이 `auth.uid()` 로 판단할 수 있게 됩니다.

### 1. localStorage 구조 통합

표시용 `roomIds` 배열과 방별 `music-room-secret-{roomId}` 키가 따로 있어 서로 어긋날 수 있었습니다. 목록에서 방을 빼도 토큰은 남고, 로컬 데이터 관리 페이지에서 지워도 절반만 지워졌습니다.

`music-rooms` 키 하나로 합쳤습니다. **목록 = 토큰을 가진 방** 이므로 어긋날 여지가 구조적으로 없어집니다.

- 레거시 키는 읽을 때마다 흡수하고 원본을 제거합니다. 한 번만 옮기지 않는 이유는 배포 직후 구버전 탭에서 만든 방이 유실되는 창을 없애기 위해서입니다.
- 로컬 데이터 관리 페이지(`/data-service/local-data`)의 키와 요약 표시도 함께 수정했습니다. 이 페이지에서 삭제하면 소유권을 잃게 되므로 설명 문구에 경고를 넣었습니다.
- 목록 노출 토글과 `MAX_MUSIC_COUNT`(방 3개 제한)를 제거했습니다. 숨긴 방을 다시 보려면 방 ID 를 직접 입력해야 해서 실질적으로 쓰기 어려운 기능이었고, 삭제 기능이 그 자리를 대신합니다.

**기존 사용자 영향**: 숨겨뒀던 방이 목록에 다시 나타납니다. 토큰이 없어 목록에만 담아뒀던 방(남의 방)은 사라집니다.

### 2. 사용하지 않는 예시 방 특수 처리 제거

특정 UUID 를 하드코딩해 비교하는 분기가 두 파일에 흩어져 있었습니다. 현재 쓰이지 않는 기능이라 걷어냈습니다.

### 3. 실시간 구독의 재연결 처리 보완

익명 로그인이 소켓을 재설정하면서 드러난 문제들입니다. **원래 있던 결함이며**, 토큰 갱신(약 1시간)이나 네트워크 끊김에서도 동일하게 발생하던 것들입니다. 교사가 화면을 오래 켜두는 사용 패턴이라 실시간이 조용히 멈출 수 있었습니다.

- `TIMED_OUT` 이 어느 분기에도 걸리지 않아 '접속 중' 상태로 멈추던 문제
- `CLOSED` 에서 재시도 없이 포기하던 문제
- 채널 정리 순서 때문에 재시도가 자기 자신을 물고 돌던 문제. `removeChannel` 은 그 채널의 콜백을 `CLOSED` 로 동기 호출하는데, 어느 채널에서 온 콜백인지 구분하지 않아 무한 루프가 됐습니다
- 토큰 갱신 시 재구독

### 4. 교사 익명 로그인과 소유권 등록

- `room_members` 테이블과 `claim_room` RPC 추가. 테이블은 정책 4개를 모두 `false` 로 잠그고 테이블 권한도 회수했습니다. `SECURITY DEFINER` 함수만 접근합니다
- 정책 안에서 `room_members` 를 직접 조회하면 그 테이블의 RLS 까지 평가되므로 `is_room_member()` 헬퍼로 감쌌습니다. `STABLE` 로 표시해 행마다 재실행되지 않게 했습니다
- `create_room` 이 `auth.uid()` 로 소유자를 함께 등록합니다. 세션이 없는 호출은 등록만 건너뛰므로 구버전 클라이언트에 영향이 없습니다
- 등록이 끝난 뒤에 조회와 realtime 구독이 시작되도록 렌더를 게이팅했습니다

**세션은 필요할 때만 만듭니다.** 익명 계정은 `auth.users` 에 영구히 쌓이므로, 방이 없는 교사가 페이지를 구경만 하고 나가는 경우까지 계정을 만들면 실제 사용자 수와 어긋납니다.

| 상황 | 세션 |
|---|---|
| 목록 진입, 방 0개 | 만들지 않음 |
| 목록 진입, 방 있음 | 생성 + 소유권 등록 |
| 방 만들기 | 생성 |
| 남의 방 URL 진입 | 만들지 않음 (안내 화면) |
| 학생 화면 | 만들지 않음 |

**학생은 인증하지 않습니다.** 학생까지 익명 로그인시키면 MAU 가 학생 수만큼 늘어납니다. 학생은 `get_room_title`, `add_music` 두 RPC 만 사용합니다.

### 5. 방 삭제

목록 카드에서 방을 삭제할 수 있습니다. `musics`, `room_secrets`, `room_members` 는 FK 의 `ON DELETE CASCADE` 로 함께 정리됩니다.

`rooms_delete` 정책이 소속 여부를 확인하므로 소유자가 아니면 에러 없이 0건이 삭제됩니다. 구분되지 않으므로 삭제된 행을 돌려받아 확인합니다.

## 리뷰노트

**마이그레이션 2개 모두 이미 원격 DB에 적용했습니다.** 둘 다 추가와 허용 방향이라 구버전 클라이언트에 영향이 없어 배포 전에 push 했습니다.

- `20260808053056_add_room_membership.sql` — `room_members`, `claim_room`, `is_room_member`, `rooms_delete` 개방
- `20260808062158_create_room_registers_member.sql` — `create_room` 이 소유자를 함께 등록

**Supabase 대시보드에서 익명 로그인을 활성화했습니다.** `supabase/config.toml` 의 `enable_anonymous_sign_ins` 는 아직 `false` 인데, 이 파일은 로컬 스택용이라 지금은 영향이 없습니다. 다만 누군가 `supabase config push` 를 실행하면 대시보드 설정을 덮어쓰므로 별도로 맞춰둘 필요가 있습니다.

**개발 모드에서 realtime 초기 연결에 10초가 걸리고 WebSocket 에러가 찍힙니다.** StrictMode 이중 마운트로 소켓이 끊겼다 붙으면서 join 타임아웃까지 기다리는 현상이고, 프로덕션 빌드에서는 재현되지 않습니다(0.8초 내 연결 확인). 훅 상단 주석에 남겨뒀습니다.

**동작이 바뀐 부분**: 내가 만들지 않은 방의 교사 화면은 안내 문구를 표시합니다. 지금까지는 URL 만 알면 볼 수 있었는데, 조회 정책 제한 이후의 동작을 미리 적용한 것입니다.

**검증 완료**

- 스토리지가 빈 상태로 목록 진입 → 익명 계정이 생기지 않음
- 방 생성 → 계정 1개, `room_members` 1행, 상세 진입·QR 표시 정상
- 새로고침 → 계정이 늘지 않음
- 곡 신청·삭제 실시간 반영
- 오프라인 → 온라인 전환 시 자동 복구
- 방 삭제 → 목록·localStorage·관리자 페이지에서 모두 사라짐, 신청곡 함께 삭제
- 시크릿 창에서 남의 방 URL 접속 → 안내 화면, 계정 생성 없음
- 학생 페이지 → 계정 생성 없음
- 기존 데이터(레거시 키)가 있는 상태에서 목록 정상 표시, `music-room-secret-*` 소멸 확인

**후속 작업**

- **조회 범위 제한** — `rooms`·`musics` 의 SELECT 정책을 `room_members` 기준으로 좁히고 anon 테이블 권한을 회수합니다. 이번 PR 의 목적이 이 작업의 기반을 만드는 것이었습니다. **이 마이그레이션만은 반드시 배포 완료 후에 push 해야 합니다** — 먼저 적용하면 모든 교사 화면이 즉시 동작하지 않습니다.
- 관리자 페이지 등에서 삭제된 방이 교사 localStorage 에 남아 콘솔 에러가 찍힙니다. 목록에서는 건너뛰어져 사용자 영향은 없어 별건으로 미뤘습니다.
- 익명 계정 정리 배치 (`room_members` 가 비어 있고 오래된 계정)

## 스크린샷

<img width="809" height="335" alt="image" src="https://github.com/user-attachments/assets/64c0ea67-7a8e-4730-b1da-15bc22341610" />
<img width="611" height="243" alt="image" src="https://github.com/user-attachments/assets/2d2782cc-79e6-418c-9be3-86563ca247f6" />
<img width="611" height="243" alt="image" src="https://github.com/user-attachments/assets/289e4a92-7c7d-4ae3-9a41-133a9eff5b3b" />


### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
