### PR TITLE
feat: 음악신청 조회 범위를 소유한 방으로 제한

### DIFF
--- a/supabase/migrations/20260808093713_restrict_music_request_read.sql
+++ b/supabase/migrations/20260808093713_restrict_music_request_read.sql
@@ -1,0 +1,51 @@
+-- 음악신청 조회 범위를 소유한 방으로 제한
+--
+-- 지금까지 rooms/musics 의 SELECT 정책이 USING (true) 였다.
+-- anon 키는 브라우저 번들에 공개되어 있으므로, 누구나 REST 로 모든 교실의
+-- 신청곡과 학생 이름을 조회할 수 있는 상태였다.
+--
+-- 교사 익명 로그인과 room_members 등록이 배포되어 이제 소속으로 판단할 수 있다.
+--
+-- ⚠️ 이 마이그레이션은 거부 방향이다. 구버전 클라이언트(anon 으로 테이블을 읽던)가
+--    남아 있으면 교사 화면이 즉시 동작하지 않는다. 반드시 배포 완료를 확인한 뒤 push 할 것.
+--
+-- 되돌리려면:
+--   ALTER POLICY rooms_select  ON public.rooms  USING (true);
+--   ALTER POLICY musics_select ON public.musics USING (true);
+--   GRANT ALL ON public.rooms, public.musics TO anon, authenticated;
+
+-- ─────────────────────────────────────────────
+-- 조회 정책
+-- ─────────────────────────────────────────────
+
+-- is_room_member 는 SECURITY DEFINER + STABLE 이라 room_members 의 RLS 를 우회하고
+-- 행마다 재실행되지 않는다. musics 는 곡 수만큼 평가되므로 이 점이 중요하다.
+
+ALTER POLICY rooms_select ON public.rooms
+  USING (is_room_member(id));
+
+ALTER POLICY musics_select ON public.musics
+  USING (is_room_member("roomId"));
+
+-- ─────────────────────────────────────────────
+-- 테이블 권한 정리
+-- ─────────────────────────────────────────────
+
+-- 학생은 테이블에 접근하지 않는다. get_room_title, add_music 두 RPC 만 사용하며
+-- 둘 다 SECURITY DEFINER 라 호출자의 테이블 권한이 필요 없다.
+-- 권한 자체를 회수하면 정책을 잘못 건드려도 뚫리지 않는다.
+REVOKE ALL ON public.rooms         FROM anon;
+REVOKE ALL ON public.musics        FROM anon;
+REVOKE ALL ON public.room_secrets  FROM anon;
+
+-- 교사가 실제로 필요한 것만 남긴다.
+--   rooms  : 조회(SELECT) + 방 삭제(DELETE). 방 삭제는 rooms_delete 정책이 판단한다.
+--   musics : 조회(SELECT). realtime 구독도 이 정책으로 평가된다.
+-- 방 생성과 곡 추가·삭제는 RPC(create_room, add_music, delete_music)를 거치므로
+-- 해당 테이블에 대한 쓰기 권한은 필요 없다.
+REVOKE ALL ON public.rooms         FROM authenticated;
+REVOKE ALL ON public.musics        FROM authenticated;
+REVOKE ALL ON public.room_secrets  FROM authenticated;
+
+GRANT SELECT, DELETE ON public.rooms  TO authenticated;
+GRANT SELECT          ON public.musics TO authenticated;


### PR DESCRIPTION
## 작업내용
`rooms` 와 `musics` 의 조회를 자신이 소유한 방으로 제한합니다. 이번 보안 작업의 최종 목표였습니다.

  ### 무엇이 열려 있었나

  두 테이블의 SELECT 정책이 `USING (true)` 였습니다. anon 키는 브라우저 번들에 그대로 들어있으므로, 개발자도구에서 키를 꺼내면 아래 한 줄로 **전국 모든 교실의 신청곡과 학생 이름**을 받아올 수 있었습니다.

  ```bash
  curl "$SUPABASE_URL/rest/v1/musics?select=*" -H "apikey: $ANON_KEY"
```
  .eq('id', roomId) 같은 클라이언트 필터는 보안 장치가 아닙니다. RLS 는 행마다 정책을 평가할 뿐, 클라이언트가 어떤 조건을 보냈는지 알지 못합니다. 필터를 빼면 전부 나옵니다.

 ### 변경 내용

  조회 정책을 소속 기준으로
```sql
  ALTER POLICY rooms_select  ON rooms  USING (is_room_member(id));
  ALTER POLICY musics_select ON musics USING (is_room_member("roomId"));
```
  `is_room_member` 는 SECURITY DEFINER + STABLE 입니다. 정책 안에서 `room_members` 를 직접 조회하면 그 테이블의 RLS 까지 평가되어 걸리고, STABLE 이 없으면 곡 수만큼 재실행됩니다.

 ### 테이블 권한 정리

  정책 위에 한 겹 더 둡니다. 정책을 잘못 건드려도 권한 단계에서 막히도록요.

|역할|rooms|musics|room_secrets|  
|---|---|---|---|
|anon|없음|없음|없음|  
|authenticated|SELECT, DELETE|SELECT|없음|

  학생은 테이블에 접근하지 않습니다. `get_room_title` 과 `add_music` 두 RPC 만 사용하고, 둘 다 SECURITY DEFINER 라 호출자의 테이블 권한이 필요 없습니다.

  교사도 방 생성과 곡 추가·삭제는 RPC 를 거치므로, 조회와 방 삭제 권한만 남겼습니다. 방 삭제는 rooms_delete 정책이 소속을 확인합니다.

 ### 이걸로 정리되는 것

  읽기    소유한 방만            ← 이번 변경
  쓰기    전부 RPC 경유          (이전 PR들)
  삭제    소속 기준 RLS
  토큰    room_secrets 에만 존재, 외부 노출 불가

## 리뷰노트

마이그레이션은 이미 원격 DB에 적용했습니다. 이번 것은 지금까지와 달리 거부 방향이라, 구버전 클라이언트(anon 으로 테이블을 읽던)가 남아 있으면 교사 화면이 즉시 동작하지 않습니다. 앞선 PR 의 배포 완료와 동작 확인을 마친 뒤에 push 했습니다. 머지 후 별도 db push 는 필요 없습니다.

되돌리는 방법을 파일 상단 주석에 적어뒀습니다. 문제가 생기면 정책을 USING (true) 로 돌리고 권한을 복구하면 즉시 원상태가 됩니다.

### 알려진 영향
secret_token 을 잃은 교사(브라우저 데이터 삭제, 기기 변경)는 이제 자기 방을 조회조차 할 수 없습니다. 이전에는 읽기는 가능하고 삭제만 막혔습니다. 문의가 들어오면 관리자 페이지(/admin/music-request, 개발 환경 전용)에서 방 상태를 확인하고 정리해줄 수 있습니다.

### 후속 작업
- delete_music RPC 를 RLS 로 이관하고 제거합니다. 이 함수는 소유권을 정책으로 표현할 수 없던 시절의 우회로였는데, room_members 가 생기면서 존재 이유가 사라졌습니다.
- 관리자 페이지 등에서 삭제된 방이 교사 localStorage 에 남아 콘솔 에러가 찍힙니다. 목록에서는 건너뛰어져 사용자 영향은 없어 별건으로 미뤘습니다.
- 익명 계정 정리 배치

## 스크린샷

DB 정책 변경만 있어 UI 변경이 없습니다.

### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
