### PR TITLE
refactor: 음악신청 곡 삭제를 소속 기준 RLS 로 이관

### DIFF
--- a/src/apis/music-request/music-room-storage.ts
+++ b/src/apis/music-request/music-room-storage.ts
@@ -94,8 +94,6 @@ const write = (rooms: MusicRooms) => {
 
 export const getMusicRooms = () => read();
 
-export const getSecretToken = (roomId: string) => read()[roomId] ?? null;
-
 export const saveMusicRoom = (roomId: string, token: string) => {
   write({ ...read(), [roomId]: token });
 };

--- a/src/apis/music-request/musicRequest.ts
+++ b/src/apis/music-request/musicRequest.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@/utils/supabase';
-import { getSecretToken, saveMusicRoom } from './music-room-storage';
+import { saveMusicRoom } from './music-room-storage';
 
 // 입력 UI 에서 쓰는 길이 제한.
 // 실제 강제는 add_music 함수와 musics_student_name_length 제약이 하므로 셋을 함께 맞춰야 한다.
@@ -145,28 +145,29 @@ export const getMusicRequestRoom = async (params: {
 };
 
 /**
- * 음악 삭제 — RPC 함수(delete_music)를 통해 서버 측에서 토큰 검증 후 삭제
- * 클라이언트에서 musics 테이블에 직접 DELETE를 날리지 않음
+ * 음악 삭제 — musics_delete 정책이 room_members 소속 여부를 확인한다.
+ *
+ * 소유자가 아니면 에러 없이 0건이 삭제되므로, 방 삭제와 마찬가지로
+ * 삭제된 행을 돌려받아 구분한다.
  */
-export const DeleteMusicRequestMusic = async (params: {
+export const deleteMusicRequestMusic = async (params: {
   roomId: string;
   musicId: string;
-}): Promise<{}> => {
-  const secretToken = getSecretToken(params.roomId);
-
-  if (!secretToken) {
-    throw new Error('삭제 권한이 없습니다. (방 개설자만 삭제 가능)');
-  }
-
-  const { error } = await supabase.rpc('delete_music', {
-    p_room_id: params.roomId,
-    p_music_id: params.musicId,
-    p_secret_token: secretToken,
-  });
+}): Promise<void> => {
+  const { data, error } = await supabase
+    .from('musics')
+    .delete()
+    .eq('roomId', params.roomId)
+    .eq('musicId', params.musicId)
+    .select('id');
 
   if (error) {
     throw new Error(error.message);
   }
 
-  return {};
+  if (!data || data.length === 0) {
+    throw new Error(
+      '곡을 삭제할 권한이 없어요. 방을 만든 기기에서 시도해주세요.',
+    );
+  }
 };

--- a/src/containers/music-request/music-request-teacher/music-request-teacher-main/music-list/music-card/music-card.tsx
+++ b/src/containers/music-request/music-request-teacher/music-request-teacher-main/music-list/music-card/music-card.tsx
@@ -49,7 +49,14 @@ export default function MusicCard({
       return;
     }
 
-    mutate({ roomId, musicId: video.musicId });
+    mutate(
+      { roomId, musicId: video.musicId },
+      {
+        onError: (error) => {
+          toast({ title: error.message, variant: 'error' });
+        },
+      },
+    );
   };
 
   const handlePlayButton = () => {

--- a/src/hooks/apis/music-request/use-delete-music-request-music.ts
+++ b/src/hooks/apis/music-request/use-delete-music-request-music.ts
@@ -1,8 +1,8 @@
-import { DeleteMusicRequestMusic } from '@/apis/music-request/musicRequest';
+import { deleteMusicRequestMusic } from '@/apis/music-request/musicRequest';
 import { useMutation } from '@tanstack/react-query';
 
 export const useDeleteMusicRequestMusic = () => {
   return useMutation({
-    mutationFn: DeleteMusicRequestMusic,
+    mutationFn: deleteMusicRequestMusic,
   });
 };

--- a/supabase/migrations/20260808100459_music_delete_by_membership.sql
+++ b/supabase/migrations/20260808100459_music_delete_by_membership.sql
@@ -1,0 +1,17 @@
+-- 곡 삭제를 소속 기준 RLS 로 이관
+--
+-- delete_music RPC 는 소유권을 정책으로 표현할 방법이 없던 시절의 우회로였다.
+-- localStorage 의 secret_token 을 인자로 받아 함수 안에서 room_secrets 와 대조했다.
+--
+-- room_members 가 생기면서 방 삭제와 동일하게 정책으로 표현할 수 있게 되었다.
+-- 토큰의 역할은 소유권 복구(claim_room) 하나로 좁아진다.
+--
+-- 허용 방향이라 구버전 클라이언트에 영향이 없다. 구버전은 계속 delete_music 을
+-- 호출하고, 그 함수는 SECURITY DEFINER 라 이 정책과 무관하게 동작한다.
+-- 함수 제거는 배포 확인 후 별도 마이그레이션에서 한다.
+
+ALTER POLICY musics_delete ON public.musics
+  USING (is_room_member("roomId"));
+
+-- 조회 제한 때 authenticated 에게 SELECT 만 남겨뒀으므로 DELETE 를 추가한다.
+GRANT DELETE ON public.musics TO authenticated;


### PR DESCRIPTION
## 작업내용

곡 삭제를 `delete_music` RPC 에서 RLS 정책으로 옮깁니다.

### 배경

`delete_music` 은 소유권을 정책으로 표현할 방법이 없던 시절의 우회로였습니다. localStorage 의 `secret_token` 을 인자로 받아 함수 안에서 `room_secrets` 와 대조하는 구조였습니다.

`room_members` 가 생기면서 방 삭제와 동일하게 정책으로 표현할 수 있게 되어, 특수 케이스를 없애고 통일합니다.

### 변경 내용

**정책**

```sql
ALTER POLICY musics_delete ON public.musics USING (is_room_member("roomId"));
GRANT DELETE ON public.musics TO authenticated;
```

조회 제한 PR 에서 `authenticated` 에게 SELECT 만 남겨뒀으므로 DELETE 를 다시 부여합니다.

**클라이언트**

```ts
await supabase.from('musics').delete()
  .eq('roomId', roomId).eq('musicId', musicId).select('id');
```

- 소유자가 아니면 에러 없이 0건이 삭제되므로, 방 삭제와 마찬가지로 삭제된 행을 돌려받아 구분합니다
- 더 이상 쓰이지 않는 `getSecretToken` 을 스토리지 모듈에서 제거했습니다. **토큰의 역할이 소유권 복구(`claim_room`) 하나로 좁아졌습니다**
- 함수명을 `DeleteMusicRequestMusic` → `deleteMusicRequestMusic` 으로 정정했습니다. 파일 내 다른 함수들과 달리 혼자 PascalCase 였습니다

**곁들여 고친 것**: 곡 삭제 실패가 조용히 묻히고 있었습니다. `onError` 가 없어 '삭제 권한이 없습니다' 가 화면에 뜨지 않았는데, 토스트로 노출되게 했습니다.

## 리뷰노트

**마이그레이션은 이미 원격 DB에 적용했습니다.** 허용 방향이라 구버전 클라이언트에 영향이 없습니다. 구버전은 계속 `delete_music` 을 호출하고, 그 함수는 `SECURITY DEFINER` 라 이 정책과 무관하게 동작합니다.

**`delete_music` 함수는 아직 남겨뒀습니다.** 배포 전에 지우면 구버전 클라이언트의 곡 삭제가 깨집니다. 이 PR 이 머지·배포된 뒤 별도 마이그레이션으로 제거하겠습니다.

**검증 완료**

- 곡 삭제 → 목록에서 사라지고 실시간 반영
- 재생 중인 곡 삭제 시도 → 안내 문구
- 방 삭제
- 학생 곡 신청 (영향 없음)

## 스크린샷

UI 변경은 삭제 실패 시 토스트가 뜨는 것뿐입니다.

### 개발 체크리스트

<!--- 아래 목록을 확인하시고 `x` 표시를 해주세요. -->

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
