### PR TITLE
Refactor/music request cleanups

### DIFF
--- a/src/apis/music-request/music-student-storage.ts
+++ b/src/apis/music-request/music-student-storage.ts
@@ -1,0 +1,105 @@
+import Cookies from 'js-cookie';
+
+/**
+ * 학생이 방에 입장할 때 입력한 이름 보관소.
+ *
+ * 예전에는 roomId 를 키로 하는 쿠키에 저장했다. 쿠키는 모든 HTTP 요청에 자동으로
+ * 첨부되는데 서버가 이 값을 쓰지 않으므로 불필요한 전송이었고, 방마다 쿠키가
+ * 하나씩 쌓여 도메인 쿠키 용량을 잠식했다. 미성년자 이름이라 더 신경 쓸 만하다.
+ *
+ * 쿠키의 1일 만료는 유지한다. 학교 공용 기기에서 앞 학생의 이름이 계속 남아 있으면
+ * 안 되기 때문이다. localStorage 에는 만료가 없으므로 값에 시각을 담아 직접 관리한다.
+ */
+
+const STORAGE_KEY = 'music-request-students';
+
+const EXPIRES_IN_MS = 24 * 60 * 60 * 1000;
+
+type StudentEntry = {
+  name: string;
+  /** epoch milliseconds */
+  expiresAt: number;
+};
+
+/** roomId → 입력한 이름 */
+type StudentNames = Record<string, StudentEntry>;
+
+const parse = (raw: string | null): StudentNames => {
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
+const write = (names: StudentNames) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(names));
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/**
+ * 만료된 항목을 걷어내고, 예전 쿠키에 남아 있는 이름을 흡수한다.
+ *
+ * 쿠키는 1일이면 스스로 사라지지만, 그 사이 수업 중인 학생이 이름을 다시 입력하게
+ * 되는 것을 막기 위해 옮겨온다. 흡수한 쿠키는 지운다.
+ */
+const read = (roomId: string): StudentNames => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  try {
+    const stored = parse(window.localStorage.getItem(STORAGE_KEY));
+    const now = Date.now();
+
+    const alive = Object.fromEntries(
+      Object.entries(stored).filter(([, entry]) => entry?.expiresAt > now),
+    );
+
+    let hasChange = Object.keys(alive).length !== Object.keys(stored).length;
+
+    const legacyName = Cookies.get(roomId);
+
+    if (legacyName && !alive[roomId]) {
+      alive[roomId] = { name: legacyName, expiresAt: now + EXPIRES_IN_MS };
+      hasChange = true;
+    }
+
+    if (legacyName) {
+      Cookies.remove(roomId);
+    }
+
+    if (hasChange) {
+      write(alive);
+    }
+
+    return alive;
+  } catch (error) {
+    console.error(error);
+    return {};
+  }
+};
+
+export const getStudentName = (roomId: string) =>
+  read(roomId)[roomId]?.name ?? '';
+
+export const saveStudentName = (roomId: string, name: string) => {
+  write({
+    ...read(roomId),
+    [roomId]: { name, expiresAt: Date.now() + EXPIRES_IN_MS },
+  });
+};
+
+export const clearStudentName = (roomId: string) => {
+  const names = read(roomId);
+  delete names[roomId];
+  write(names);
+};

--- a/src/apis/music-request/musicRequest.ts
+++ b/src/apis/music-request/musicRequest.ts
@@ -122,6 +122,26 @@ export const deleteMusicRequestRoom = async (params: {
 };
 
 /**
+ * 방 상세 진입을 활동으로 기록한다.
+ *
+ * 곡을 추가·삭제하지 않고 재생만 하는 사용도 활동으로 잡아야 하기 때문이다.
+ * 목록 조회에서는 호출하지 않는다 — 모든 방을 한꺼번에 갱신해버린다.
+ *
+ * 부수 효과이므로 실패해도 화면 흐름을 막지 않는다.
+ */
+export const touchMusicRequestRoom = async (params: {
+  roomId: string;
+}): Promise<void> => {
+  const { error } = await supabase.rpc('touch_room', {
+    p_room_id: params.roomId,
+  });
+
+  if (error) {
+    console.error('방 활동 시각 갱신 실패:', error.message);
+  }
+};
+
+/**
  * 방 정보 + 음악 목록 조회 (외래키 조인으로 단일 쿼리)
  */
 export const getMusicRequestRoom = async (params: {

--- a/src/app/admin/music-request/page.tsx
+++ b/src/app/admin/music-request/page.tsx
@@ -7,11 +7,18 @@ export const metadata = {
 
 export const dynamic = 'force-dynamic';
 
-export default function AdminMusicRequestPage() {
+type Props = {
+  searchParams: {
+    sort?: string;
+    dir?: string;
+  };
+};
+
+export default function AdminMusicRequestPage({ searchParams }: Props) {
   // 미들웨어가 /admin 을 막지만, matcher 설정 실수 등으로 구멍이 생기지 않도록 여기서도 확인한다.
   if (process.env.NODE_ENV !== 'development') {
     notFound();
   }
 
-  return <AdminMusicRequestContainer />;
+  return <AdminMusicRequestContainer searchParams={searchParams} />;
 }

--- a/src/constants/localStorageGroups.ts
+++ b/src/constants/localStorageGroups.ts
@@ -66,6 +66,11 @@ export const LOCAL_STORAGE_KEY_META: Record<
     description:
       '음악 신청에서 만든 방(교실) 목록입니다. 방을 만든 사람임을 증명하는 값이 함께 저장되며, 지우면 해당 방의 신청곡을 삭제할 수 없게 됩니다.',
   },
+  'music-request-students': {
+    label: '음악 신청 입력한 이름',
+    description:
+      '음악 신청 방에 입장할 때 입력한 이름입니다. 입력 후 하루가 지나면 자동으로 사라집니다.',
+  },
   routines: {
     label: '루틴 목록',
     description: '루틴 타이머에 저장한 루틴 목록입니다.',
@@ -117,7 +122,7 @@ export const LOCAL_STORAGE_GROUPS = [
   {
     id: 'music-request',
     label: '음악신청',
-    keys: ['music-rooms'],
+    keys: ['music-rooms', 'music-request-students'],
   },
   {
     id: 'routine-timer',

--- a/src/containers/admin/music-request/admin-music-request-container.tsx
+++ b/src/containers/admin/music-request/admin-music-request-container.tsx
@@ -10,11 +10,16 @@ import {
 } from '@/components/table';
 import { supabaseAdmin } from '@/utils/supabase-admin';
 import DeleteRoomButton from './delete-room-button';
+import SortableHead, { parseDirection, parseSort } from './sortable-head';
+
+/** PostgREST 기본 상한. 이 수만큼 왔다면 뒤가 잘렸을 수 있다. */
+const MAX_ROWS = 1000;
 
 type AdminRoom = {
   id: string;
   roomTitle: string;
   connectedAt: string;
+  lastActivityAt: string;
   musics: { id: number; title: string; studentName: string }[];
 };
 
@@ -24,7 +29,22 @@ const formatKst = (value: string) =>
 const getStudentNames = (musics: AdminRoom['musics']) =>
   Array.from(new Set(musics.map((music) => music.studentName)));
 
-export default async function AdminMusicRequestContainer() {
+const getDaysAgo = (value: string) =>
+  Math.floor((Date.now() - new Date(value).getTime()) / (24 * 60 * 60 * 1000));
+
+type Props = {
+  searchParams: {
+    sort?: string;
+    dir?: string;
+  };
+};
+
+export default async function AdminMusicRequestContainer({
+  searchParams,
+}: Props) {
+  const sort = parseSort(searchParams.sort);
+  const direction = parseDirection(searchParams.dir);
+
   if (!supabaseAdmin) {
     return (
       <div className="flex flex-col gap-y-4">
@@ -38,10 +58,14 @@ export default async function AdminMusicRequestContainer() {
     );
   }
 
+  // 정렬은 반드시 DB 에서 해야 한다. 응답이 MAX_ROWS 로 잘리므로,
+  // 가져온 뒤 JS 에서 정렬하면 잘린 바깥쪽 행을 영영 볼 수 없다.
   const { data, error } = await supabaseAdmin
     .from('rooms')
-    .select('id, roomTitle, connectedAt, musics(id, title, studentName)')
-    .order('connectedAt', { ascending: false });
+    .select(
+      'id, roomTitle, connectedAt, lastActivityAt, musics(id, title, studentName)',
+    )
+    .order(sort, { ascending: direction === 'asc' });
 
   if (error) {
     return (
@@ -53,6 +77,7 @@ export default async function AdminMusicRequestContainer() {
   }
 
   const rooms = (data ?? []) as AdminRoom[];
+
   const totalMusicCount = rooms.reduce(
     (sum, room) => sum + room.musics.length,
     0,
@@ -62,18 +87,50 @@ export default async function AdminMusicRequestContainer() {
     <div className="flex flex-col gap-y-6">
       <Heading1>음악신청 관리</Heading1>
 
-      <p className="text-sm text-gray-500">
-        방 {rooms.length}개 · 신청곡 {totalMusicCount}곡
-      </p>
+      <div className="flex flex-col gap-1">
+        <p className="text-sm text-gray-500">
+          방 {rooms.length}개 · 신청곡 {totalMusicCount}곡
+        </p>
+        {rooms.length >= MAX_ROWS && (
+          <p className="text-sm text-red">
+            {MAX_ROWS}개까지만 조회됩니다. 정렬을 바꿔 반대쪽을 확인하세요.
+          </p>
+        )}
+      </div>
 
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[22%]">방 제목</TableHead>
-            <TableHead className="w-[14%]">방 ID</TableHead>
-            <TableHead className="w-[14%]">생성</TableHead>
-            <TableHead className="w-[8%]">곡</TableHead>
-            <TableHead className="w-[34%]">학생</TableHead>
+            <SortableHead
+              label="방 제목"
+              sortKey="roomTitle"
+              activeSort={sort}
+              activeDirection={direction}
+              className="w-[20%]"
+            />
+            <SortableHead
+              label="방 ID"
+              sortKey="id"
+              activeSort={sort}
+              activeDirection={direction}
+              className="w-[10%]"
+            />
+            <SortableHead
+              label="생성"
+              sortKey="connectedAt"
+              activeSort={sort}
+              activeDirection={direction}
+              className="w-[14%]"
+            />
+            <SortableHead
+              label="마지막 활동"
+              sortKey="lastActivityAt"
+              activeSort={sort}
+              activeDirection={direction}
+              className="w-[16%]"
+            />
+            <TableHead className="w-[6%]">곡</TableHead>
+            <TableHead className="w-[26%]">학생</TableHead>
             <TableHead className="w-[8%]" />
           </TableRow>
         </TableHeader>
@@ -89,6 +146,12 @@ export default async function AdminMusicRequestContainer() {
                 </TableCell>
                 <TableCell className="text-xs text-gray-500">
                   {formatKst(room.connectedAt)}
+                </TableCell>
+                <TableCell className="text-xs text-gray-500">
+                  {formatKst(room.lastActivityAt)}
+                  <span className="block text-gray-400">
+                    {getDaysAgo(room.lastActivityAt)}일 전
+                  </span>
                 </TableCell>
                 <TableCell>{room.musics.length}</TableCell>
                 <TableCell className="truncate text-xs text-gray-500">

--- a/src/containers/admin/music-request/sortable-head.tsx
+++ b/src/containers/admin/music-request/sortable-head.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+import { TableHead } from '@/components/table';
+
+/** 정렬 가능한 컬럼. PostgREST 로 그대로 넘기므로 화이트리스트로 제한한다. */
+export const SORT_KEYS = [
+  'roomTitle',
+  'id',
+  'connectedAt',
+  'lastActivityAt',
+] as const;
+
+export type SortKey = (typeof SORT_KEYS)[number];
+export type SortDirection = 'asc' | 'desc';
+
+export const parseSort = (value?: string): SortKey =>
+  SORT_KEYS.includes(value as SortKey) ? (value as SortKey) : 'lastActivityAt';
+
+export const parseDirection = (value?: string): SortDirection =>
+  value === 'desc' ? 'desc' : 'asc';
+
+type Props = {
+  label: string;
+  sortKey: SortKey;
+  activeSort: SortKey;
+  activeDirection: SortDirection;
+  className?: string;
+};
+
+export default function SortableHead({
+  label,
+  sortKey,
+  activeSort,
+  activeDirection,
+  className,
+}: Props) {
+  const isActive = activeSort === sortKey;
+
+  // 같은 컬럼을 다시 누르면 방향을 뒤집고, 다른 컬럼이면 오름차순부터 시작한다
+  const nextDirection: SortDirection =
+    isActive && activeDirection === 'asc' ? 'desc' : 'asc';
+
+  return (
+    <TableHead className={className}>
+      <Link
+        href={`?sort=${sortKey}&dir=${nextDirection}`}
+        className="flex items-center gap-1 hover:text-text-title"
+      >
+        {label}
+        {!isActive && <ChevronsUpDown size={14} className="text-gray-400" />}
+        {isActive && activeDirection === 'asc' && <ChevronUp size={14} />}
+        {isActive && activeDirection === 'desc' && <ChevronDown size={14} />}
+      </Link>
+    </TableHead>
+  );
+}

--- a/src/containers/data-service/local-data/local-data-container.tsx
+++ b/src/containers/data-service/local-data/local-data-container.tsx
@@ -244,6 +244,21 @@ function getValueDisplay(key: string): DisplayValue {
         };
       }
 
+      if (
+        key === 'music-request-students' &&
+        parsed &&
+        typeof parsed === 'object'
+      ) {
+        const names = Object.values(parsed as Record<string, { name?: string }>)
+          .map((entry) => entry?.name)
+          .filter(Boolean);
+        if (names.length === 0) return { summary: '저장된 데이터 없음' };
+        return {
+          summary: `이름 ${names.length}개`,
+          detail: names.join(', '),
+        };
+      }
+
       if (key === 'routines' && Array.isArray(parsed)) {
         const arr = parsed as { name?: string }[];
         if (arr.length === 0) return { summary: '저장된 데이터 없음' };

--- a/src/containers/music-request/music-request-student/music-request-student-main/create-name-page/create-name-page.tsx
+++ b/src/containers/music-request/music-request-student/music-request-student-main/create-name-page/create-name-page.tsx
@@ -1,4 +1,3 @@
-import Cookies from 'js-cookie';
 import { Input } from '@/components/input';
 import {
   Form,
@@ -12,6 +11,10 @@ import { Button } from '@/components/button';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { MAX_STUDENT_NAME_LENGTH } from '@/apis/music-request/musicRequest';
+import {
+  clearStudentName,
+  saveStudentName,
+} from '@/apis/music-request/music-student-storage';
 import {
   useMusicRequestStudentAction,
   useMusicRequestStudentState,
@@ -50,9 +53,7 @@ export default function CreateNamePage({ roomId }: Props) {
   });
 
   const handleStudentName = async (name: string) => {
-    Cookies.set(roomId, name, {
-      expires: 1,
-    });
+    saveStudentName(roomId, name);
     settingStudentName(name);
   };
 
@@ -65,7 +66,7 @@ export default function CreateNamePage({ roomId }: Props) {
               ? (event) => {
                   form.reset();
                   event.preventDefault();
-                  Cookies.remove(roomId);
+                  clearStudentName(roomId);
                   settingStudentName('');
                 }
               : form.handleSubmit((values) =>

--- a/src/containers/music-request/music-request-student/music-request-student-provider/music-request-student-provider.tsx
+++ b/src/containers/music-request/music-request-student/music-request-student-provider/music-request-student-provider.tsx
@@ -1,11 +1,12 @@
-import Cookies from 'js-cookie';
 import {
   createContext,
   Dispatch,
   PropsWithChildren,
   SetStateAction,
+  useEffect,
   useState,
 } from 'react';
+import { getStudentName } from '@/apis/music-request/music-student-storage';
 
 interface PropsWithChildrenParams extends PropsWithChildren {
   roomId: string;
@@ -29,9 +30,12 @@ export default function MusicRequestStudentProvider({
   children,
   roomId,
 }: PropsWithChildrenParams) {
-  const [studentName, setStudentName] = useState<string>(
-    Cookies.get(roomId) || '',
-  );
+  // localStorage 는 서버에서 읽을 수 없어 첫 렌더 이후에 채운다
+  const [studentName, setStudentName] = useState<string>('');
+
+  useEffect(() => {
+    setStudentName(getStudentName(roomId));
+  }, [roomId]);
 
   const defaultMusicRequestStudentStateValue = {
     studentName,

--- a/src/containers/music-request/music-request-teacher/music-request-teacher-container.tsx
+++ b/src/containers/music-request/music-request-teacher/music-request-teacher-container.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useMusicRooms } from '@/apis/music-request/music-room-storage';
+import { touchMusicRequestRoom } from '@/apis/music-request/musicRequest';
 import { useMusicRoomSession } from '@/hooks/apis/music-request/use-music-room-session';
 import LoadingSpinner from '@/components/loading-spinner';
 import MusicRequestTeacherMain from './music-request-teacher-main/music-request-teacher-main';
@@ -29,6 +31,16 @@ export default function MusicRequestTeacherContainer({ params }: Props) {
   const { isReady, isError } = useMusicRoomSession({
     enabled: isLoaded && isOwnedRoom,
   });
+
+  // 곡을 추가·삭제하지 않고 재생만 하는 사용도 활동으로 기록해야 한다.
+  // 목록 조회가 아니라 상세 진입만 갱신하는 것이 핵심이다.
+  useEffect(() => {
+    if (!isReady || !isOwnedRoom) {
+      return;
+    }
+
+    touchMusicRequestRoom({ roomId: params.roomId });
+  }, [isReady, isOwnedRoom, params.roomId]);
 
   if (!isLoaded) {
     return <LoadingSpinner />;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -175,7 +175,7 @@ refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
 # Allow/disallow anonymous sign-ins to your project.
-enable_anonymous_sign_ins = false
+enable_anonymous_sign_ins = true
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.

--- a/supabase/migrations/20260808125252_add_room_last_activity.sql
+++ b/supabase/migrations/20260808125252_add_room_last_activity.sql
@@ -1,0 +1,85 @@
+-- 방의 마지막 활동 시각을 컬럼으로 관리
+--
+-- 오래 방치된 방을 골라내려면 "언제까지 쓰였는지"가 필요하다.
+-- 곡의 timeStamp 로 계산할 수도 있지만 두 가지를 놓친다.
+--   1) 곡 삭제 — 곡이 사라지면 그 흔적도 사라진다
+--   2) 재생만 하는 사용 — 교사가 플레이리스트를 한 번 만들어두고 수업마다 재생만
+--      하는 경우, 곡 추가·삭제가 없어 활동으로 잡히지 않는다. 실제로는 가장
+--      활발히 쓰이는 방인데 정리 대상으로 오인될 수 있다.
+--
+-- 갱신 시점은 셋이다.
+--   방 생성       → 컬럼 기본값
+--   곡 추가·삭제  → musics 트리거
+--   상세 페이지 진입 → touch_room RPC (Postgres 에 SELECT 트리거가 없어 명시 호출)
+--
+-- 목록 조회는 갱신하지 않는다. 목록은 모든 방을 한꺼번에 읽으므로 갱신하면
+-- 방치된 방까지 전부 최신으로 만들어 버린다.
+--
+-- 허용·추가 방향이라 구버전 클라이언트에 영향이 없다.
+
+-- ─────────────────────────────────────────────
+-- 컬럼
+-- ─────────────────────────────────────────────
+
+ALTER TABLE public.rooms
+  ADD COLUMN "lastActivityAt" timestamp with time zone NOT NULL DEFAULT now();
+
+-- 기존 행은 마지막 곡의 시각으로, 곡이 없으면 방 생성 시각으로 채운다
+UPDATE public.rooms r
+SET "lastActivityAt" = COALESCE(
+  (SELECT max("timeStamp") FROM musics WHERE "roomId" = r.id),
+  r."connectedAt"
+);
+
+-- 정리 대상 조회는 이 컬럼 기준으로 정렬·필터링한다
+CREATE INDEX rooms_last_activity_at_idx ON public.rooms ("lastActivityAt");
+
+-- ─────────────────────────────────────────────
+-- 곡 추가·삭제 시 갱신
+-- ─────────────────────────────────────────────
+
+-- rooms_update 정책이 USING (false) 이므로 SECURITY DEFINER 가 필수다.
+-- 일반 역할로 실행되면 트리거의 UPDATE 가 차단되어 곡 신청 자체가 롤백된다.
+CREATE OR REPLACE FUNCTION public.touch_room_last_activity()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+AS $function$
+BEGIN
+  UPDATE rooms
+  SET "lastActivityAt" = now()
+  WHERE id = COALESCE(NEW."roomId", OLD."roomId");
+
+  RETURN NULL;
+END;
+$function$;
+
+CREATE TRIGGER musics_touch_room_last_activity
+  AFTER INSERT OR DELETE ON public.musics
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_room_last_activity();
+
+-- ─────────────────────────────────────────────
+-- 상세 페이지 진입 시 갱신
+-- ─────────────────────────────────────────────
+
+-- 부수 효과라 실패해도 화면 흐름을 막지 않는다. 소속이 아니면 조용히 넘어간다.
+CREATE OR REPLACE FUNCTION public.touch_room(p_room_id uuid)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF NOT is_room_member(p_room_id) THEN
+    RETURN;
+  END IF;
+
+  UPDATE rooms
+  SET "lastActivityAt" = now()
+  WHERE id = p_room_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.touch_room(uuid) TO authenticated;


### PR DESCRIPTION
## 작업내용

보안 작업 이후 미뤄뒀던 항목들을 정리합니다. 서로 독립적인 네 가지라 커밋을 나눴습니다.

### 1. 학생 이름 저장을 쿠키에서 localStorage 로

`Cookies.set(roomId, name, { expires: 1 })` 로 저장하고 있었습니다. 문제가 셋이었습니다.

- **쿠키는 모든 HTTP 요청에 자동으로 첨부됩니다.** 서버가 이 값을 쓰지 않는데도 페이지·API·이미지 요청마다 전송되고 있었습니다. 미성년자 이름이라 더 신경 쓸 만합니다
- `roomId` 를 그대로 쿠키 키로 써서 네임스페이스가 없었습니다
- 방마다 쿠키가 하나씩 쌓여 도메인 쿠키 용량(4KB)을 잠식했습니다. 미들웨어가 `fontSize`, `screenMode` 쿠키를 쓰고 있어 같은 공간을 공유합니다

`music-request-students` 키 하나에 `roomId` 별로 보관하도록 옮겼습니다.

**1일 만료는 유지했습니다.** 공용 기기에서 앞 학생 이름이 계속 남아 있으면 안 되기 때문입니다. localStorage 에는 만료가 없으므로 값에 시각을 담아 읽을 때 걸러냅니다.

**기존 쿠키는 읽을 때 흡수하고 제거합니다.** 쿠키는 1일이면 스스로 사라지지만, 그 사이 수업 중인 학생이 이름을 다시 입력하게 되는 상황을 막습니다.

**방마다 이름을 따로 두는 기존 동작은 유지했습니다.** 기기당 하나로 바꾸면 편해지지만, 공용 태블릿에서 앞 학생 이름이 미리 채워진 채 신청되면 엉뚱한 학생이 신청한 것으로 기록됩니다. 빈 칸으로 시작하는 편이 안전하다고 판단했습니다.

로컬 데이터 관리 페이지에도 키와 요약 표시를 등록했습니다.

### 2. 방의 마지막 활동 시각

오래 방치된 방을 골라내려면 "언제까지 쓰였는지" 가 필요합니다. 곡의 `timeStamp` 로 계산하는 방법도 검토했지만 두 가지를 놓칩니다.

1. **곡 삭제** — 곡이 사라지면 그 흔적도 사라집니다
2. **재생만 하는 사용** — 교사가 플레이리스트를 한 번 만들어두고 수업마다 재생만 하는 방은 곡 추가·삭제가 없어 활동으로 잡히지 않습니다. 실제로는 가장 활발히 쓰이는 방인데 정리 대상으로 오인될 수 있습니다

`rooms.lastActivityAt` 컬럼을 추가하고 세 시점에 갱신합니다.

| 시점 | 방법 |
|---|---|
| 방 생성 | 컬럼 기본값 |
| 곡 추가·삭제 | `musics` 트리거 |
| 상세 페이지 진입 | `touch_room` RPC |

**목록 조회는 갱신하지 않습니다.** 목록은 모든 방을 한꺼번에 읽으므로, 거기서 갱신하면 방치된 방까지 전부 최신이 되어 정리 대상이 사라집니다.

상세 진입은 Postgres 에 SELECT 트리거가 없어 명시적으로 호출해야 합니다.

기존 행은 마지막 곡의 시각(곡이 없으면 방 생성 시각)으로 백필했습니다. 기본값만 두면 모든 방이 "지금 활동함" 이 되어 판별이 무의미해집니다.

### 3. 관리자 페이지 컬럼 정렬

PostgREST 기본 상한인 1000개까지만 조회되는데 오래된 순으로 고정 정렬되어 있어, 최근 갱신된 방을 확인할 수 없었습니다.

방 제목·방 ID·생성·마지막 활동에 오름/내림 정렬을 붙였습니다. URL 쿼리로 상태를 관리해 서버 컴포넌트에서 처리하므로 클라이언트 JS 가 필요 없습니다.

**정렬은 반드시 DB 에서 해야 합니다.** 가져온 뒤 JS 로 정렬하면 상한에 잘려나간 행을 영영 볼 수 없습니다.

1000개에 닿으면 안내 문구를 표시합니다. 곡·학생 컬럼은 조인 결과라 SQL 정렬이 불가능해 제외했습니다.

### 4. `config.toml` 익명 로그인

대시보드에서는 활성화했는데 `config.toml` 은 `false` 였습니다. 이 파일은 로컬 스택용이라 지금 당장 영향은 없지만, `supabase config push` 를 실행하면 대시보드 설정을 덮어써서 익명 로그인이 꺼집니다.

## 리뷰노트

**마이그레이션은 추가·허용 방향이라 배포 전에 push 했습니다.** 트리거 함수가 `SECURITY DEFINER` 라 구버전 클라이언트의 곡 신청도 그대로 동작합니다.

**트리거의 `SECURITY DEFINER` 가 필수입니다.** `rooms_update` 정책이 `USING (false)` 이므로, 일반 역할로 실행되면 트리거의 UPDATE 가 차단되고 **곡 신청 자체가 롤백됩니다.** 리뷰 시 이 부분을 확인해주세요.

**정렬 키는 화이트리스트로 제한했습니다.** URL 값을 그대로 PostgREST 에 넘기면 임의 컬럼 정렬이 가능해집니다.

**검증 완료**

- 학생 이름 입력 → localStorage 저장, 쿠키 제거 확인
- 기존 쿠키가 있는 상태에서 진입 → 흡수되고 이름 유지
- 다시 입력하기 → 항목 제거
- 곡 추가·삭제 → `lastActivityAt` 갱신 (트리거 동작 확인)
- 상세 페이지 진입만 → 갱신됨
- 목록 페이지만 방문 → 갱신되지 않음
- 각 컬럼 정렬, 방향 반전, 잘못된 쿼리 값 처리

**남은 것**

- 방이 2000개를 넘으면 정렬만으로는 가운데가 사각지대가 됩니다. `lastActivityAt` 인덱스를 만들어뒀으니 `.range()` 로 페이지네이션을 붙일 수 있습니다
- 익명 계정 정리 배치 — `lastActivityAt` 이 생겨 정리 기준을 세우기 쉬워졌습니다
- 삭제된 방이 교사 localStorage 에 남아 콘솔 에러가 찍히는 문제 (사용자 영향 없음)

## 스크린샷

<img width="1363" height="635" alt="image" src="https://github.com/user-attachments/assets/5d083bdd-0a25-47e5-b8b3-c2ddfd3eef2e" />

### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
