### PR TITLE
Refactor/local data management

### DIFF
--- a/src/apis/music-request/music-request-cleanup.ts
+++ b/src/apis/music-request/music-request-cleanup.ts
@@ -1,0 +1,25 @@
+import { ensureMusicRoomSession } from '@/hooks/apis/music-request/use-music-room-session';
+import { getMusicRooms } from './music-room-storage';
+import { deleteMusicRequestRooms } from './musicRequest';
+
+/**
+ * 음악신청 데이터를 서버까지 정리한다.
+ *
+ * 로컬에는 방 소유 증명만 있고 실제 방과 신청곡은 서버에 있다. 교사에게는 그 구분이
+ * 구현 세부사항이므로, 로컬 데이터를 지웠는데 본인은 볼 수도 없는 서버 데이터가
+ * 남으면 "삭제했다"는 경험과 어긋난다.
+ *
+ * 호출하는 쪽에서 로컬 키를 지우기 전에 먼저 실행해야 한다. 순서가 반대면 서버 삭제가
+ * 실패했을 때 방을 다시 찾을 수 없다.
+ */
+export const clearMusicRequestServerData = async () => {
+  const roomIds = Object.keys(getMusicRooms());
+
+  if (roomIds.length === 0) {
+    return;
+  }
+
+  // 방 삭제는 room_members 소속 확인을 거치므로 세션이 필요하다
+  await ensureMusicRoomSession();
+  await deleteMusicRequestRooms(roomIds);
+};

--- a/src/apis/music-request/music-student-storage.ts
+++ b/src/apis/music-request/music-student-storage.ts
@@ -3,28 +3,22 @@ import Cookies from 'js-cookie';
 /**
  * 학생이 방에 입장할 때 입력한 이름 보관소.
  *
- * 예전에는 roomId 를 키로 하는 쿠키에 저장했다. 쿠키는 모든 HTTP 요청에 자동으로
- * 첨부되는데 서버가 이 값을 쓰지 않으므로 불필요한 전송이었고, 방마다 쿠키가
- * 하나씩 쌓여 도메인 쿠키 용량을 잠식했다. 미성년자 이름이라 더 신경 쓸 만하다.
+ * sessionStorage 를 쓴다. 탭을 닫으면 사라지고 새로고침에는 살아남는데, 학생에게
+ * 필요한 보존 범위가 딱 그만큼이다. 학교 공용 기기에서 앞 학생의 이름이 남지 않고,
+ * 교사가 관리할 데이터도 아니게 된다.
  *
- * 쿠키의 1일 만료는 유지한다. 학교 공용 기기에서 앞 학생의 이름이 계속 남아 있으면
- * 안 되기 때문이다. localStorage 에는 만료가 없으므로 값에 시각을 담아 직접 관리한다.
+ * 예전에는 쿠키(1일), 그다음에는 localStorage(만료 시각 직접 관리)를 썼다.
+ * 쿠키는 서버가 쓰지도 않는 값이 모든 요청에 첨부되는 문제가 있었고,
+ * localStorage 는 탭을 닫아도 남아 만료 처리를 직접 해야 했다.
+ * 탭 수명을 그대로 보관 정책으로 삼으면 그 코드가 전부 사라진다.
  */
 
 const STORAGE_KEY = 'music-request-students';
 
-const EXPIRES_IN_MS = 24 * 60 * 60 * 1000;
-
-type StudentEntry = {
-  name: string;
-  /** epoch milliseconds */
-  expiresAt: number;
-};
-
 /** roomId → 입력한 이름 */
-type StudentNames = Record<string, StudentEntry>;
+type StudentNames = Record<string, string>;
 
-const parse = (raw: string | null): StudentNames => {
+const parse = (raw: string | null): Record<string, unknown> => {
   if (!raw) {
     return {};
   }
@@ -39,63 +33,78 @@ const parse = (raw: string | null): StudentNames => {
 
 const write = (names: StudentNames) => {
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(names));
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(names));
   } catch (error) {
     console.error(error);
   }
 };
 
 /**
- * 만료된 항목을 걷어내고, 예전 쿠키에 남아 있는 이름을 흡수한다.
+ * 예전 저장소에 남은 이름을 흡수하고 원본을 지운다.
  *
- * 쿠키는 1일이면 스스로 사라지지만, 그 사이 수업 중인 학생이 이름을 다시 입력하게
- * 되는 것을 막기 위해 옮겨온다. 흡수한 쿠키는 지운다.
+ * localStorage 쪽은 데이터 관리 페이지에서도 항목을 뺐기 때문에, 여기서 치우지 않으면
+ * 사용자가 지울 방법이 없는 데이터로 남는다.
  */
+const absorbLegacy = (names: StudentNames, roomId: string) => {
+  const merged = { ...names };
+  let hasChange = false;
+
+  const legacyLocal = parse(window.localStorage.getItem(STORAGE_KEY));
+
+  Object.entries(legacyLocal).forEach(([key, entry]) => {
+    const name = (entry as { name?: string })?.name;
+
+    if (name && !merged[key]) {
+      merged[key] = name;
+      hasChange = true;
+    }
+  });
+
+  if (Object.keys(legacyLocal).length > 0) {
+    window.localStorage.removeItem(STORAGE_KEY);
+    hasChange = true;
+  }
+
+  const legacyCookie = Cookies.get(roomId);
+
+  if (legacyCookie) {
+    if (!merged[roomId]) {
+      merged[roomId] = legacyCookie;
+    }
+
+    Cookies.remove(roomId);
+    hasChange = true;
+  }
+
+  return { merged, hasChange };
+};
+
 const read = (roomId: string): StudentNames => {
   if (typeof window === 'undefined') {
     return {};
   }
 
   try {
-    const stored = parse(window.localStorage.getItem(STORAGE_KEY));
-    const now = Date.now();
-
-    const alive = Object.fromEntries(
-      Object.entries(stored).filter(([, entry]) => entry?.expiresAt > now),
-    );
-
-    let hasChange = Object.keys(alive).length !== Object.keys(stored).length;
-
-    const legacyName = Cookies.get(roomId);
-
-    if (legacyName && !alive[roomId]) {
-      alive[roomId] = { name: legacyName, expiresAt: now + EXPIRES_IN_MS };
-      hasChange = true;
-    }
-
-    if (legacyName) {
-      Cookies.remove(roomId);
-    }
+    const stored = parse(
+      window.sessionStorage.getItem(STORAGE_KEY),
+    ) as StudentNames;
+    const { merged, hasChange } = absorbLegacy(stored, roomId);
 
     if (hasChange) {
-      write(alive);
+      write(merged);
     }
 
-    return alive;
+    return merged;
   } catch (error) {
     console.error(error);
     return {};
   }
 };
 
-export const getStudentName = (roomId: string) =>
-  read(roomId)[roomId]?.name ?? '';
+export const getStudentName = (roomId: string) => read(roomId)[roomId] ?? '';
 
 export const saveStudentName = (roomId: string, name: string) => {
-  write({
-    ...read(roomId),
-    [roomId]: { name, expiresAt: Date.now() + EXPIRES_IN_MS },
-  });
+  write({ ...read(roomId), [roomId]: name });
 };
 
 export const clearStudentName = (roomId: string) => {

--- a/src/apis/music-request/musicRequest.ts
+++ b/src/apis/music-request/musicRequest.ts
@@ -122,6 +122,26 @@ export const deleteMusicRequestRoom = async (params: {
 };
 
 /**
+ * 여러 방을 한 번에 삭제한다. 로컬 데이터 관리에서 음악신청 데이터를 통째로 지울 때 쓴다.
+ *
+ * 소속이 아니거나 이미 사라진 방은 조용히 빠진다. 실제로 지워진 id 를 돌려주지만,
+ * 호출부는 "더 이상 쓰지 않겠다"는 의도로 부르는 것이므로 남은 항목도 함께 정리한다.
+ */
+export const deleteMusicRequestRooms = async (
+  roomIds: string[],
+): Promise<void> => {
+  if (roomIds.length === 0) {
+    return;
+  }
+
+  const { error } = await supabase.from('rooms').delete().in('id', roomIds);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+};
+
+/**
  * 방 상세 진입을 활동으로 기록한다.
  *
  * 곡을 추가·삭제하지 않고 재생만 하는 사용도 활동으로 잡아야 하기 때문이다.

--- a/src/constants/localStorageGroups.ts
+++ b/src/constants/localStorageGroups.ts
@@ -64,12 +64,7 @@ export const LOCAL_STORAGE_KEY_META: Record<
   'music-rooms': {
     label: '음악 신청 방 목록',
     description:
-      '음악 신청에서 만든 방(교실) 목록입니다. 방을 만든 사람임을 증명하는 값이 함께 저장되며, 지우면 해당 방의 신청곡을 삭제할 수 없게 됩니다.',
-  },
-  'music-request-students': {
-    label: '음악 신청 입력한 이름',
-    description:
-      '음악 신청 방에 입장할 때 입력한 이름입니다. 입력 후 하루가 지나면 자동으로 사라집니다.',
+      '음악 신청에서 만든 방(교실) 목록입니다. 지우면 모든 방의 정보와 신청곡이 함께 삭제되며, 되돌릴 수 없습니다.',
   },
   routines: {
     label: '루틴 목록',
@@ -122,7 +117,7 @@ export const LOCAL_STORAGE_GROUPS = [
   {
     id: 'music-request',
     label: '음악신청',
-    keys: ['music-rooms', 'music-request-students'],
+    keys: ['music-rooms'],
   },
   {
     id: 'routine-timer',

--- a/src/containers/data-service/local-data/local-data-container.tsx
+++ b/src/containers/data-service/local-data/local-data-container.tsx
@@ -20,6 +20,7 @@ import {
 import { getPathDisplayTitle } from '@/constants/route';
 import { ALLERGY_MAP } from '@/containers/landing/lunch-menu/allergy/allergy.constant';
 import { cn } from '@/styles/utils';
+import { runServerCleanup } from './server-cleanup';
 
 /** 객체/배열 항목을 [object Object] 없이 짧은 읽기 쉬운 문자열로 변환 */
 function itemToReadable(item: unknown): string {
@@ -244,21 +245,6 @@ function getValueDisplay(key: string): DisplayValue {
         };
       }
 
-      if (
-        key === 'music-request-students' &&
-        parsed &&
-        typeof parsed === 'object'
-      ) {
-        const names = Object.values(parsed as Record<string, { name?: string }>)
-          .map((entry) => entry?.name)
-          .filter(Boolean);
-        if (names.length === 0) return { summary: '저장된 데이터 없음' };
-        return {
-          summary: `이름 ${names.length}개`,
-          detail: names.join(', '),
-        };
-      }
-
       if (key === 'routines' && Array.isArray(parsed)) {
         const arr = parsed as { name?: string }[];
         if (arr.length === 0) return { summary: '저장된 데이터 없음' };
@@ -366,46 +352,67 @@ export default function LocalDataContainer() {
     setIsReady(true);
   }, []);
 
-  const handleDeleteKey = (key: string) => {
+  const handleDeleteKey = async (key: string) => {
     if (typeof window === 'undefined') return;
+    await runServerCleanup(key);
     window.localStorage.removeItem(key);
     refresh();
   };
 
-  const handleDeleteGroup = (groupId: string) => {
+  const handleDeleteGroup = async (groupId: string) => {
     if (typeof window === 'undefined') return;
     const group = LOCAL_STORAGE_GROUPS.find((g) => g.id === groupId);
     if (group) {
+      await Promise.all(group.keys.map(runServerCleanup));
       group.keys.forEach((key) => window.localStorage.removeItem(key));
       refresh();
     }
   };
 
-  const handleDeleteAll = () => {
+  const handleDeleteAll = async () => {
     if (typeof window === 'undefined') return;
-    LOCAL_STORAGE_GROUPS.forEach((group) => {
-      group.keys.forEach((key) => window.localStorage.removeItem(key));
-    });
+    const keys = LOCAL_STORAGE_GROUPS.flatMap((group) => group.keys);
+    await Promise.all(keys.map(runServerCleanup));
+    keys.forEach((key) => window.localStorage.removeItem(key));
     refresh();
   };
 
-  const handleConfirmDelete = () => {
+  const handleConfirmDelete = async () => {
     if (!deleteTarget) return;
-    if (deleteTarget.type === 'key') handleDeleteKey(deleteTarget.key);
-    else if (deleteTarget.type === 'group')
-      handleDeleteGroup(deleteTarget.groupId);
-    else if (deleteTarget.type === 'all') handleDeleteAll();
     setDeleteTarget(null);
+
+    try {
+      if (deleteTarget.type === 'key') await handleDeleteKey(deleteTarget.key);
+      else if (deleteTarget.type === 'group')
+        await handleDeleteGroup(deleteTarget.groupId);
+      else if (deleteTarget.type === 'all') await handleDeleteAll();
+    } catch (error) {
+      console.error('데이터 삭제 실패:', error);
+    }
   };
 
+  // 되돌릴 수 없는 항목이 섞여 있으므로 무엇이 사라지는지 확인 시점에 함께 보여준다
   const confirmMessage = (() => {
     if (!deleteTarget) return '';
-    if (deleteTarget.type === 'key')
-      return `"${getKeyLabel(deleteTarget.key)}" 데이터를 삭제하시겠습니까?`;
-    if (deleteTarget.type === 'group')
-      return '이 그룹의 모든 로컬 데이터를 삭제하시겠습니까?';
+
+    if (deleteTarget.type === 'key') {
+      return `"${getKeyLabel(deleteTarget.key)}" 데이터를 삭제하시겠습니까?\n\n${getKeyDescription(deleteTarget.key)}`;
+    }
+
+    if (deleteTarget.type === 'group') {
+      const group = LOCAL_STORAGE_GROUPS.find(
+        (item) => item.id === deleteTarget.groupId,
+      );
+      const descriptions = (group?.keys ?? [])
+        .map((key) => getKeyDescription(key))
+        .join('\n\n');
+
+      return `이 그룹의 모든 데이터를 삭제하시겠습니까?\n\n${descriptions}`;
+    }
+
     if (deleteTarget.type === 'all')
-      return '모든 로컬 데이터를 삭제하시겠습니까? 앱에 저장된 설정·데이터가 모두 제거됩니다.';
+      return '모든 데이터를 삭제하시겠습니까? 앱에 저장된 설정·데이터가 모두 제거됩니다.';
+
     return '';
   })();
 
@@ -506,7 +513,9 @@ export default function LocalDataContainer() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>삭제 확인</AlertDialogTitle>
-            <AlertDialogDescription>{confirmMessage}</AlertDialogDescription>
+            <AlertDialogDescription className="whitespace-pre-line">
+              {confirmMessage}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>취소</AlertDialogCancel>

--- a/src/containers/data-service/local-data/server-cleanup.ts
+++ b/src/containers/data-service/local-data/server-cleanup.ts
@@ -1,0 +1,24 @@
+import { clearMusicRequestServerData } from '@/apis/music-request/music-request-cleanup';
+
+/**
+ * 로컬 키를 지우기 전에 함께 정리해야 하는 서버 데이터.
+ *
+ * 로컬 데이터 관리 페이지는 브라우저 저장소를 지우는 곳이지만, 기능에 따라 실제
+ * 데이터가 서버에 있는 경우가 있다. 사용자에게는 그 구분이 구현 세부사항이므로
+ * "삭제"가 반쪽만 이뤄지지 않도록 여기서 이어준다.
+ *
+ * ── 새 기능을 추가할 때 ──
+ * 정리 함수는 각 기능 쪽(예: apis/<기능>/...)에 두고 여기서는 연결만 한다.
+ * 컨테이너가 모든 기능의 내부를 직접 import 하면 데이터 관리 페이지가 전체 기능에
+ * 의존하게 되고, 여러 개발자가 같은 파일을 고치게 된다.
+ *
+ * 기능이 별도 Supabase 프로젝트를 쓰더라도(투표 등) 각자의 정리 함수 안에서
+ * 자기 클라이언트를 쓰면 되므로 이 파일은 그대로 둘 수 있다.
+ */
+const SERVER_CLEANUP_BY_KEY: Record<string, () => Promise<void>> = {
+  'music-rooms': clearMusicRequestServerData,
+};
+
+/** 해당 키에 서버 정리가 필요하면 실행한다. 없으면 아무 일도 하지 않는다. */
+export const runServerCleanup = (key: string) =>
+  SERVER_CLEANUP_BY_KEY[key]?.() ?? Promise.resolve();


### PR DESCRIPTION
## 작업내용

로컬 데이터 관리 페이지의 삭제가 브라우저 저장소만 지우고 있었습니다. 음악신청은 로컬에 방 소유 증명만 있고 실제 방과 신청곡은 서버에 있어서, 지워도 절반만 사라지는 상태였습니다.

### 왜 서버까지 지워야 하나

데이터 관리 페이지에서 지웠는데 **본인은 볼 수도 없는 서버 데이터가 남아 있다면** 그게 오히려 신뢰를 깎습니다. 음악신청 데이터를 지우는 것은 "더 이상 이 기능을 쓰지 않겠다" 는 의도이므로, 방과 신청곡도 함께 삭제하는 것이 기대에 맞습니다.

### 1. 삭제를 서버까지 이어줍니다

로컬 키를 지우기 전에 서버 데이터를 먼저 정리합니다. **순서가 반대면 서버 삭제가 실패했을 때 방을 다시 찾을 수 없습니다.**

세션은 삭제 시점에만 확보합니다. 페이지에 들어오기만 해서는 익명 계정이 생기지 않고, 방이 0개면 아예 호출하지 않습니다.

### 2. 컨테이너가 기능을 직접 알지 않게 했습니다

`local-data-container.tsx` 는 여러 기능이 함께 쓰는 파일입니다. 정리 로직을 여기 두면 기능이 늘 때마다 이 파일이 그 기능의 내부를 import 하게 되어, 데이터 관리 페이지가 전체 기능에 의존하게 됩니다.

```
local-data-container.tsx
  └─ import { runServerCleanup } from './server-cleanup';   ← 이 하나만

server-cleanup.ts                              ← 키에 연결만 하는 얇은 파일
  └─ 'music-rooms': clearMusicRequestServerData

apis/music-request/music-request-cleanup.ts    ← 실제 로직은 기능 쪽에
```

새 기능을 추가할 때 따라야 할 규칙은 `server-cleanup.ts` 주석에 적어뒀습니다. 투표처럼 별도 Supabase 프로젝트를 쓰는 기능도 각자의 정리 함수 안에서 자기 클라이언트를 쓰면 되므로 이 구조가 그대로 유지됩니다.

### 3. 확인 다이얼로그에 설명을 함께 보여줍니다

되돌릴 수 없는 삭제인데 `"음악 신청 방 목록" 데이터를 삭제하시겠습니까?` 라는 공통 문구만 나오고 있었습니다. 이제 항목 설명이 함께 표시됩니다. 다른 기능에도 같이 적용되는 개선입니다.

### 4. 학생 이름을 sessionStorage 로 전환하고 목록에서 뺐습니다

**데이터 관리 페이지에서 제외** — 하루면 사라지는 학생 소유 데이터라 교사에게 의미가 없고, 목록에 "학생 이름" 이 보이면 이 앱이 학생 정보를 모아둔다는 오해를 부를 수 있습니다.

**sessionStorage 로 전환** — 탭을 닫으면 사라지고 새로고침에는 살아남습니다. 학생에게 필요한 보존 범위가 딱 그만큼이라, 교사가 관리할 데이터가 아니게 되어 목록에서 뺀 것과도 맞습니다.

탭 수명이 곧 보관 정책이 되면서 만료 시각 필드와 읽을 때마다 걸러내던 스윕 로직이 전부 사라졌습니다.

**예전 저장소 정리** — 쿠키와 localStorage 에 남은 이름은 읽을 때 흡수하고 원본을 제거합니다. 특히 localStorage 는 이번에 데이터 관리 페이지에서도 항목을 뺐기 때문에, 치우지 않으면 사용자가 지울 방법이 없는 데이터로 남습니다.

## 리뷰노트

**DB 마이그레이션이 없습니다.** 정책·스키마 변경 없이 클라이언트만 바뀌므로 배포 순서를 신경 쓸 필요가 없습니다.

**페이지 이름과 어긋나는 부분이 생겼습니다.** `로컬 데이터 관리` 인데 음악신청만 서버 데이터까지 지웁니다. 다른 그룹은 순수 로컬입니다. 항목 설명에 무엇이 사라지는지 적어 오해를 줄였지만, 페이지 개명(`내 데이터 관리` 등)은 메뉴·경로에 영향이 있어 별건으로 뒀습니다.

**검증 완료**

- 방을 만든 상태에서 데이터 관리 → `방 N개` 표시, 학생 이름 항목 없음
- 삭제 확인 다이얼로그에 설명 표시
- 삭제 후 음악신청 목록이 비고, **관리자 페이지에서도 방이 사라짐**
- 방이 0개일 때 삭제 → 에러 없이 통과
- 학생 이름: 새로고침 유지 / 탭 닫으면 사라짐
- 예전 localStorage 키가 있는 상태에서 진입 → 흡수 후 키 제거 확인

**남은 것**

- 데이터 관리 페이지는 방 개수만 보여줍니다. 개별 방 삭제는 음악신청 목록 페이지에 이미 있고, 거기가 썸네일·곡 수·학생 이름까지 보여 판단하기 좋습니다. 이 페이지의 고유한 역할은 "전부 정리" 로 두었습니다
- 정리 함수는 localStorage 키 단위로 등록됩니다. 한 기능이 키를 여러 개 갖고 서버 정리는 하나뿐인 경우가 생기면 그룹 단위로 바꾸는 것이 맞습니다

## 스크린샷

<img width="676" height="251" alt="image" src="https://github.com/user-attachments/assets/55f70218-2ff9-4515-bb62-db6d34dd6565" />

### 개발 체크리스트

- [x] 나는 PR 제목을 문장형으로 가독성있게 작성했다.
- [x] 나는 변경 사항에 대해 크롬에서 테스트를 했다.
